### PR TITLE
Add CLI scraping workflow and macOS helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.log
+*.sqlite3
+*.db
+playwright-report/
+data/app.db

--- a/Open-App.command
+++ b/Open-App.command
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -euo pipefail
 open "http://127.0.0.1:5000/"

--- a/README.md
+++ b/README.md
@@ -37,16 +37,38 @@ tenpadel/
 └── requirements.txt             # Dépendances Python
 ```
 
-## Installation
+## Installation manuelle (alternative aux boutons)
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt
-playwright install
+python -m playwright install chromium
+python app.py
 ```
 
-## Lancer l’application
+## Boutons macOS prêts à l’emploi
+
+Chaque fichier `*.command` est exécutable depuis Finder (double-clic). Lors du tout
+premier lancement macOS peut bloquer le script : ouvrez **Réglages Système →
+Confidentialité & Sécurité** puis cliquez sur **Ouvrir quand même**.
+
+| Script | Rôle |
+| --- | --- |
+| `Start-TenPadel.command` | Crée/active `.venv`, installe les dépendances, prépare `data/` et lance `app.py`. |
+| `Stop-TenPadel.command` | Coupe le serveur Flask qui écoute sur `http://127.0.0.1:5000`. |
+| `Open-App.command` | Ouvre l’interface dans le navigateur par défaut. |
+| `Scrape-TenUp.command` | Active l’environnement, assure Playwright, exporte `PYTHONPATH` puis lance `python -m services.scrape`. |
+| `Scrape-TenUp-Module.command` | Variante qui exécute directement `python -m scrapers.tenup`. |
+
+> ℹ️ L’exécution de `Scrape-TenUp.command` n’a **pas** besoin que le serveur Flask
+> tourne : la persistance SQLite + JSON est réalisée hors-ligne via le module Python.
+
+Toutes ces commandes sont idempotentes : relancez-les autant de fois que
+nécessaire.
+
+## Lancer l’application (mode manuel)
 
 ```bash
 python app.py

--- a/Scrape-TenUp-Module.command
+++ b/Scrape-TenUp-Module.command
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")" || exit 1
+
+echo "🎾 Scraping TenUp (module Python)…"
+
+PY="/usr/local/bin/python3"
+[ -x "$PY" ] || PY="python3"
+if [ ! -d ".venv" ]; then
+  "$PY" -m venv .venv
+fi
+source .venv/bin/activate
+
+pip install --upgrade pip setuptools wheel >/dev/null
+pip install -r requirements.txt >/dev/null
+python -m playwright install chromium >/dev/null 2>&1 || true
+
+export PYTHONPATH="$PWD"
+
+python -m scrapers.tenup && echo "✅ Scrape Python OK" || { echo "❌ Scrape Python KO"; exit 1; }
+
+echo "💾 Vérifie data/tournaments.json"

--- a/Start-TenPadel.command
+++ b/Start-TenPadel.command
@@ -1,25 +1,24 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")" || exit 1
+
 echo "🚀 Starting TenPadel…"
 
-# 1) venv
+PY="/usr/local/bin/python3"
+[ -x "$PY" ] || PY="python3"
+
 if [ ! -d ".venv" ]; then
-  /usr/bin/python3 -m venv .venv || python3 -m venv .venv
+  "$PY" -m venv .venv
 fi
 source .venv/bin/activate
 
-# 2) deps visibles
 pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt
-
-# 3) playwright
 python -m playwright install chromium
 
-# 4) data
 mkdir -p data data/logs
 touch data/app.db
+touch data/tournaments.json
 chmod -R u+rwX,go+rwX data
 
-# 5) démarrer
 python app.py

--- a/Stop-TenPadel.command
+++ b/Stop-TenPadel.command
@@ -1,8 +1,9 @@
 #!/bin/bash
-PID=$(lsof -ti tcp:5000)
+set -e
+PID=$(lsof -ti tcp:5000 || true)
 if [ -n "$PID" ]; then
-  echo "🧹 Arrêt du serveur Flask (PID: $PID)..."
+  echo "🧹 Stop Flask (PID $PID)…"
   kill "$PID" || kill -9 "$PID"
 else
-  echo "⚠️ Aucun serveur trouvé sur le port 5000."
+  echo "ℹ️ Aucun serveur sur le port 5000."
 fi

--- a/scrapers/tenup.py
+++ b/scrapers/tenup.py
@@ -446,7 +446,7 @@ def _load_config() -> Dict[str, object]:
         return json.load(fh)
 
 
-def _cli_args() -> argparse.Namespace:
+def _cli_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Scrape TenUp padel tournaments")
     parser.add_argument("--category", action="append", help="Filtrer par catégorie (H, F, MIXTE)")
     parser.add_argument("--from", dest="date_from", help="Date de début (YYYY-MM-DD)")
@@ -458,11 +458,11 @@ def _cli_args() -> argparse.Namespace:
     parser.add_argument("--limit", type=int, default=200, help="Nombre maximum de tournois à récupérer")
     parser.add_argument("--output", help="Fichier JSON de sortie")
     parser.add_argument("--dry-run", action="store_true", help="Écrire un JSON de démonstration")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def _cli_main() -> int:  # pragma: no cover - CLI entry point
-    args = _cli_args()
+def _cli_main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - CLI entry point
+    args = _cli_args(argv)
     config = _load_config()
     scraper = TenUpScraper(config.get("tenup", {}))
 
@@ -501,6 +501,10 @@ def _cli_main() -> int:  # pragma: no cover - CLI entry point
     return 0
 
 
+def main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - CLI entry point
+    return _cli_main(argv)
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    raise SystemExit(_cli_main())
+    raise SystemExit(main())
 

--- a/services/scrape.py
+++ b/services/scrape.py
@@ -1,16 +1,28 @@
-"""High level helpers to orchestrate TenUp scraping flows."""
+"""High level helpers and CLI to orchestrate TenUp scraping flows."""
 from __future__ import annotations
 
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
 from time import perf_counter
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import pendulum
-
+from flask import Flask
 from loguru import logger
 
+from extensions import db
 from models.tournament import Tournament
 from scrapers.tenup import TenUpScraper
+from services.tournament_store import TournamentStore
 
+BASE_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = BASE_DIR / "data"
+DATABASE_PATH = DATA_DIR / "app.db"
+DEFAULT_JSON_PATH = DATA_DIR / "tournaments.json"
+CONFIG_PATH = BASE_DIR / "config.json"
 
 DEFAULT_CATEGORIES = ("H", "F", "MIXTE")
 
@@ -76,3 +88,152 @@ def scrape_tenup(
         "geo": geo,
         "fetched": len(tournaments),
     }
+
+
+def _load_config(path: Path = CONFIG_PATH) -> Dict[str, object]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing configuration file: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _ensure_storage(json_path: Path) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    (DATA_DIR / "logs").mkdir(parents=True, exist_ok=True)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    DATABASE_PATH.touch(exist_ok=True)
+
+
+def _create_app(sqlite_path: Path) -> Flask:
+    app = Flask("tenpadel-scraper")
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{sqlite_path}",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    return app
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Scrape TenUp tournaments and persist them to the local storage",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        help="Filtrer par catégorie (H, F, MIXTE). Peut être utilisé plusieurs fois.",
+    )
+    parser.add_argument("--from", dest="date_from", help="Date de début (YYYY-MM-DD)")
+    parser.add_argument("--to", dest="date_to", help="Date de fin (YYYY-MM-DD)")
+    parser.add_argument("--region", help="Filtrer par région")
+    parser.add_argument("--city", help="Filtrer par ville")
+    parser.add_argument("--radius-km", type=int, help="Rayon géographique en kilomètres")
+    parser.add_argument(
+        "--level",
+        action="append",
+        help="Filtrer par niveau (ex: P250, P500). Peut être utilisé plusieurs fois.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Nombre maximum de tournois à récupérer (par catégorie).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Fichier JSON de sortie (défaut: data/tournaments.json)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Ne pas persister en base, afficher seulement le résumé.",
+    )
+    return parser
+
+
+def _resolve_cli_parameters(config: Dict[str, object], args: argparse.Namespace) -> Dict[str, object]:
+    tenup_config = config.get("tenup", {}) if config else {}
+
+    categories = [token.strip().upper() for token in (args.category or []) if token.strip()]
+    if not categories:
+        default_categories = tenup_config.get("default_categories") or DEFAULT_CATEGORIES
+        categories = [str(token).upper() for token in default_categories]
+
+    levels = [token.strip().upper() for token in (args.level or []) if token.strip()]
+
+    limit = args.limit
+    if limit in (None, 0):
+        limit = tenup_config.get("max_results")
+
+    radius = args.radius_km
+    if radius in (None, 0):
+        radius = tenup_config.get("default_radius_km")
+
+    region = args.region or tenup_config.get("default_region")
+    city = args.city or tenup_config.get("default_city")
+
+    return {
+        "categories": categories,
+        "date_from": args.date_from,
+        "date_to": args.date_to,
+        "region": region,
+        "city": city,
+        "radius_km": radius,
+        "level": levels or None,
+        "limit": limit,
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        config = _load_config()
+    except FileNotFoundError as exc:  # pragma: no cover - CLI usage
+        parser.error(str(exc))
+        return 2
+
+    json_output = args.output or DEFAULT_JSON_PATH
+    _ensure_storage(json_output)
+
+    flask_app = _create_app(DATABASE_PATH)
+    params = _resolve_cli_parameters(config, args)
+    store = TournamentStore(db, json_output)
+
+    with flask_app.app_context():
+        db.create_all()
+        try:
+            tournaments, meta = scrape_tenup(config, **params)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Scraping failed", error=str(exc))
+            print(f"❌ Scraping TenUp échoué: {exc}", file=sys.stderr)
+            return 1
+
+        total = len(tournaments)
+        print(
+            "🎯 TenUp scraping terminé",
+            f"(catégories={meta.get('categories')}, période={meta.get('date_from')}->{meta.get('date_to')})",
+        )
+        print(f"   → Tournois récupérés: {total}")
+
+        if args.dry_run:
+            print("ℹ️ Mode --dry-run: aucune écriture en base/JSON.")
+            return 0
+
+        stats = store.upsert_many(tournaments)
+        summary = stats.as_dict()
+        print(
+            "✅ Persistance SQLite/JSON terminée:",
+            f"insérés={summary['inserted']}",
+            f"mis-à-jour={summary['updated']}",
+            f"inchangés={summary['skipped']}",
+        )
+        print(f"   → Base SQLite: {DATABASE_PATH}")
+        print(f"   → Export JSON : {json_output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone CLI entry point in `services.scrape` that loads config, initialises the database, and persists scraped tournaments without hitting the Flask API
- expose a reusable `main()` guard in `scrapers.tenup` for module execution
- refresh the macOS helper scripts, add a module variant, and document the one-click workflow in the README while ignoring generated SQLite files

## Testing
- python3 -m services.scrape --help
- python3 -c "import app"


------
https://chatgpt.com/codex/tasks/task_e_68e2ea2833c083219264b2045e697e0e