### PR TITLE
Refactor TenUp scraping pipeline for Playwright-only workflow

### DIFF
--- a/Scrape-TenUp.command
+++ b/Scrape-TenUp.command
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")" || exit 1
-
 echo "🎾 Scraping TenUp (sans API)…"
 
-PY="/usr/local/bin/python3"
-[ -x "$PY" ] || PY="python3"
-if [ ! -d ".venv" ]; then
-  "$PY" -m venv .venv
-fi
+PY="/usr/local/bin/python3"; [ -x "$PY" ] || PY="python3"
+[ -d ".venv" ] || "$PY" -m venv .venv
 source .venv/bin/activate
 
 pip install --upgrade pip setuptools wheel >/dev/null
@@ -17,26 +13,14 @@ python -m playwright install chromium >/dev/null 2>&1 || true
 
 mkdir -p data data/logs
 touch data/app.db
-touch data/tournaments.json
 chmod -R u+rwX,go+rwX data
 
 export PYTHONPATH="$PWD"
-
-if python - <<'PY'
-import importlib.util, sys
-spec = importlib.util.find_spec("services.scrape")
-sys.exit(0 if spec else 1)
-PY
-then
-  echo "➡️  python -m services.scrape"
-  python -m services.scrape
-else
-  echo "➡️  python -m scrapers.tenup"
-  python -m scrapers.tenup
-fi
+echo "➡️  python -m services.scrape"
+python -m services.scrape
 
 if [ -f "data/tournaments.json" ]; then
-  echo "✅ Scraping terminé. Fichier mis à jour : data/tournaments.json"
+  echo "✅ Scraping ok → data/tournaments.json"
 else
-  echo "⚠️ Scraping terminé, mais data/tournaments.json est introuvable."
+  echo "⚠️ Scraping terminé, pas de tournaments.json"
 fi

--- a/scrapers/tenup.py
+++ b/scrapers/tenup.py
@@ -1,510 +1,606 @@
-"""Scraper implementation for the TenUp padel tournaments catalogue."""
+"""Playwright-based scraper for TenUp padel tournaments."""
 from __future__ import annotations
 
-import argparse
-import json
+import logging
 import random
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence
+from urllib.parse import urljoin
 
-import httpx
 import pendulum
-from loguru import logger
-from playwright.sync_api import (Error as PlaywrightError, Locator, Page,
-                                 TimeoutError as PlaywrightTimeoutError,
-                                 sync_playwright)
-
-from models.tournament import Tournament
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
-
-_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+from playwright.sync_api import (  # type: ignore[import-untyped]
+    Browser,
+    BrowserContext,
+    Error as PlaywrightError,
+    Locator,
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+    sync_playwright,
 )
 
 
-@dataclass
-class FetchContext:
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
+
+@dataclass(slots=True)
+class ScrapedTournament:
+    """Normalised structure returned by :class:`TenUpScraper`."""
+
+    tournament_id: str
+    name: str
+    level: Optional[str]
     category: str
-    date_from: str
-    date_to: str
-    geo: Dict[str, object]
-    level: Sequence[str]
-    limit: int
+    club_name: Optional[str]
+    club_code: Optional[str]
+    organizer: Optional[str]
+    city: Optional[str]
+    region: Optional[str]
+    address: Optional[str]
+    start_date: str
+    end_date: str
+    registration_deadline: Optional[str]
+    surface: Optional[str]
+    indoor_outdoor: Optional[str]
+    draw_size: Optional[int]
+    price: Optional[float]
+    status: Optional[str]
+    detail_url: str
+    registration_url: Optional[str]
+    last_scraped_at: str
+
+    def asdict(self) -> Dict[str, object]:
+        return {
+            "tournament_id": self.tournament_id,
+            "name": self.name,
+            "level": self.level,
+            "category": self.category,
+            "club_name": self.club_name,
+            "club_code": self.club_code,
+            "organizer": self.organizer,
+            "city": self.city,
+            "region": self.region,
+            "address": self.address,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "registration_deadline": self.registration_deadline,
+            "surface": self.surface,
+            "indoor_outdoor": self.indoor_outdoor,
+            "draw_size": self.draw_size,
+            "price": self.price,
+            "status": self.status,
+            "detail_url": self.detail_url,
+            "registration_url": self.registration_url,
+            "last_scraped_at": self.last_scraped_at,
+        }
 
 
 class TenUpScraper:
-    """Fetch padel tournaments from TenUp using Playwright or the public API."""
+    """Scrape the TenUp tournament catalogue via Playwright only."""
 
-    def __init__(self, config: Dict[str, object]) -> None:
-        self.config = config or {}
-        self.base_url = self.config.get("base_url", "https://tenup.fft.fr/recherche/tournois")
-        self.headless = bool(self.config.get("headless", True))
-        self.request_timeout = int(self.config.get("request_timeout_ms", 30000))
-        self.max_results = int(self.config.get("max_results", 500))
-        self.respect_rate_limit = bool(self.config.get("respect_rate_limit", True))
-        self.log = logger.bind(component="TenUpScraper")
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        headless: bool = True,
+        request_timeout_ms: int = 30000,
+        respect_rate_limit: bool = True,
+        log_path: Optional[Path] = None,
+        random_delay_range: tuple[float, float] = (1.2, 2.0),
+        max_retries: int = 3,
+    ) -> None:
+        self.base_url = base_url
+        self.headless = headless
+        self.request_timeout_ms = request_timeout_ms
+        self.respect_rate_limit = respect_rate_limit
+        self.random_delay_range = random_delay_range
+        self.max_retries = max_retries
+        self._logger = logging.getLogger("scrapers.tenup")
+        self._log_path = Path(log_path) if log_path else None
+        if self._log_path:
+            self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            handler = logging.FileHandler(self._log_path, encoding="utf-8")
+            handler.setLevel(logging.INFO)
+            formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+            handler.setFormatter(formatter)
+            if not any(isinstance(h, logging.FileHandler) and h.baseFilename == handler.baseFilename for h in self._logger.handlers):
+                self._logger.addHandler(handler)
+        self._logger.setLevel(logging.INFO)
+        self._page: Optional[Page] = None
+        self._context: Optional[BrowserContext] = None
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def fetch_tournaments(
+    def scrape(
         self,
-        category: str,
+        *,
+        region: Optional[str],
         date_from: str,
         date_to: str,
-        geo: Dict[str, object],
-        level: Sequence[str],
-        limit: int = 500,
-    ) -> List[Tournament]:
-        """Fetch tournaments for a single category."""
-
-        ctx = FetchContext(
-            category=category,
-            date_from=date_from,
-            date_to=date_to,
-            geo=geo,
-            level=level,
-            limit=min(limit, self.max_results),
-        )
-
-        self.log.info(
-            "Fetching tournaments", category=ctx.category, period=f"{ctx.date_from}->{ctx.date_to}", level=list(level)
-        )
-
-        items: List[Tournament] = []
-        try:
-            api_payload = self._fetch_via_api(ctx)
-            if api_payload:
-                items.extend(api_payload)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            self.log.warning("API lookup failed, falling back to Playwright", error=str(exc))
-
-        if not items:
-            try:
-                items.extend(self._fetch_via_playwright(ctx))
-            except Exception as exc:  # pragma: no cover - defensive logging
-                self.log.error("Playwright scraping failed", error=str(exc))
-
-        deduped = self._deduplicate(items)
-        self.log.info("Fetched %d tournaments", len(deduped))
-        return deduped[: ctx.limit]
-
-    def fetch_all(
-        self,
         categories: Iterable[str],
+        levels: Sequence[str],
+        limit: int,
+    ) -> List[ScrapedTournament]:
+        """Return a normalised list of tournaments matching the filters."""
+
+        self._logger.info(
+            "Starting TenUp scrape",
+            extra={
+                "region": region,
+                "date_from": date_from,
+                "date_to": date_to,
+                "categories": list(categories),
+                "levels": list(levels),
+                "limit": limit,
+            },
+        )
+        try:
+            with sync_playwright() as playwright:
+                browser = self._launch_browser(playwright)
+                try:
+                    context = self._new_context(browser)
+                    self._context = context
+                    page = context.new_page()
+                    self._page = page
+                    tournaments = self._scrape_with_page(
+                        page,
+                        region=region,
+                        date_from=date_from,
+                        date_to=date_to,
+                        categories=list(categories),
+                        levels=list(levels),
+                        limit=limit,
+                    )
+                finally:
+                    self._page = None
+                    if self._context is not None:
+                        self._context.close()
+                        self._context = None
+                    browser.close()
+        except Exception:
+            self._capture_debug_artifacts()
+            raise
+
+        deduped: Dict[str, ScrapedTournament] = {}
+        for item in tournaments:
+            deduped[item.tournament_id] = item
+        sorted_items = sorted(deduped.values(), key=lambda item: item.start_date or "")
+        self._logger.info("Scrape completed", extra={"count": len(sorted_items)})
+        return sorted_items[:limit]
+
+    # ------------------------------------------------------------------
+    # Browser helpers
+    # ------------------------------------------------------------------
+    def _launch_browser(self, playwright) -> Browser:
+        return playwright.chromium.launch(headless=self.headless)
+
+    def _new_context(self, browser: Browser) -> BrowserContext:
+        context = browser.new_context(
+            locale="fr-FR",
+            timezone_id="Europe/Paris",
+            user_agent=_USER_AGENT,
+            viewport={"width": 1440, "height": 900},
+        )
+        return context
+
+    def _scrape_with_page(
+        self,
+        page: Page,
+        *,
+        region: Optional[str],
         date_from: str,
         date_to: str,
-        geo: Optional[Dict[str, object]] = None,
-        level: Sequence[str] | None = None,
-        limit: int | None = None,
-    ) -> List[Tournament]:
-        """Fetch tournaments for several categories."""
+        categories: Sequence[str],
+        levels: Sequence[str],
+        limit: int,
+    ) -> List[ScrapedTournament]:
+        self._goto_home(page)
+        self._accept_cookies(page)
+        self._apply_filters(page, region=region, date_from=date_from, date_to=date_to, levels=levels)
 
-        geo = geo or {}
-        level = level or []
-        limit = limit or self.max_results
-        aggregated: List[Tournament] = []
-        for category in categories:
-            tournaments = self.fetch_tournaments(category, date_from, date_to, geo, level, limit)
-            aggregated.extend(tournaments)
-            if self.respect_rate_limit:
-                time.sleep(random.uniform(0.3, 0.9))
-        return self._deduplicate(aggregated)
-
-    # ------------------------------------------------------------------
-    # API fetching helpers
-    # ------------------------------------------------------------------
-    def _fetch_via_api(self, ctx: FetchContext) -> List[Tournament]:
-        """Attempt to use TenUp's JSON API if the endpoint is known."""
-
-        endpoint = self.config.get("api_endpoint")
-        if not endpoint:
-            return []
-
-        params = self._build_query_params(ctx)
-        headers = {"User-Agent": _USER_AGENT, "Accept": "application/json"}
-        timeout = self.request_timeout / 1000.0
-        response = httpx.get(endpoint, params=params, headers=headers, timeout=timeout)
-        response.raise_for_status()
-        data = response.json()
-        return self._normalise_api_payload(data)
-
-    def _build_query_params(self, ctx: FetchContext) -> Dict[str, object]:
-        params: Dict[str, object] = {
-            "discipline": "PADEL",
-            "category": ctx.category,
-            "dateFrom": ctx.date_from,
-            "dateTo": ctx.date_to,
-            "limit": ctx.limit,
-        }
-        if ctx.geo.get("region"):
-            params["region"] = ctx.geo["region"]
-        if ctx.geo.get("city"):
-            params["city"] = ctx.geo["city"]
-        if ctx.geo.get("radius_km"):
-            params["radius"] = ctx.geo["radius_km"]
-        if ctx.level:
-            params["level"] = ",".join(ctx.level)
-        return params
-
-    def _normalise_api_payload(self, payload: Dict[str, object]) -> List[Tournament]:
-        tournaments: List[Tournament] = []
-        results = payload.get("items") or payload.get("data") or []
-        if not isinstance(results, list):
-            return []
-
-        for raw in results:
-            tournament = self._build_tournament(raw)
-            if tournament:
-                tournaments.append(tournament)
+        tournaments: List[ScrapedTournament] = []
+        seen_urls: set[str] = set()
+        for category in [token.upper() for token in (categories or ("MIXTE",))]:
+            self._select_category(page, category)
+            self._refresh_results(page)
+            items = self._collect_list_items(page, limit)
+            for summary in items:
+                if summary.detail_url in seen_urls:
+                    continue
+                seen_urls.add(summary.detail_url)
+                tournaments.append(summary)
+                if len(tournaments) >= limit:
+                    break
+            if len(tournaments) >= limit:
+                break
         return tournaments
 
     # ------------------------------------------------------------------
-    # Playwright fallback
+    # Navigation helpers
     # ------------------------------------------------------------------
-    def _fetch_via_playwright(self, ctx: FetchContext) -> List[Tournament]:
-        """Drive the TenUp UI with Playwright when no API is available."""
-
-        items: List[Tournament] = []
-        with sync_playwright() as playwright:
-            browser = playwright.chromium.launch(headless=self.headless)
-            context = browser.new_context(
-                locale="fr-FR",
-                timezone_id="Europe/Paris",
-                user_agent=_USER_AGENT,
-            )
-            page = context.new_page()
-            try:
-                self._load_page(page)
-                self._accept_cookies(page)
-                self._apply_filters(page, ctx)
-                items = self._collect_from_dom(page, ctx.limit)
-            finally:
-                context.close()
-                browser.close()
-        return items
-
-    def _load_page(self, page: Page) -> None:
-        page.goto(self.base_url, wait_until="domcontentloaded", timeout=self.request_timeout)
-        page.wait_for_load_state("networkidle", timeout=self.request_timeout)
+    def _goto_home(self, page: Page) -> None:
+        page.goto(self.base_url, wait_until="domcontentloaded", timeout=self.request_timeout_ms)
+        page.wait_for_load_state("networkidle", timeout=self.request_timeout_ms)
 
     def _accept_cookies(self, page: Page) -> None:
         try:
-            button = page.get_by_role("button", name="Tout accepter", exact=True)
+            button = page.get_by_role("button", name=re.compile("accepter", re.I))
             if button.is_visible():
                 button.click()
-                page.wait_for_load_state("networkidle", timeout=self.request_timeout)
-        except PlaywrightTimeoutError:
-            return
-        except PlaywrightError:  # pragma: no cover - defensive
-            return
-
-    def _apply_filters(self, page: Page, ctx: FetchContext) -> None:
-        self._select_discipline(page)
-        self._select_category(page, ctx.category)
-        self._set_date_range(page, ctx.date_from, ctx.date_to)
-        if ctx.geo.get("region"):
-            self._select_region(page, str(ctx.geo["region"]))
-        if ctx.geo.get("city"):
-            self._select_city(page, str(ctx.geo["city"]), ctx.geo.get("radius_km"))
-        if ctx.level:
-            self._select_levels(page, ctx.level)
-
-    def _select_discipline(self, page: Page) -> None:
-        try:
-            page.get_by_role("button", name="Discipline").click()
-            page.get_by_role("option", name="Padel").click()
+                self._rate_limit()
         except PlaywrightError:
-            self.log.warning("Unable to select discipline – the page structure may have changed")
+            self._logger.debug("Cookie banner not displayed")
+
+    def _apply_filters(
+        self,
+        page: Page,
+        *,
+        region: Optional[str],
+        date_from: str,
+        date_to: str,
+        levels: Sequence[str],
+    ) -> None:
+        self._set_date_field(page, "Date de début", date_from)
+        self._set_date_field(page, "Date de fin", date_to)
+        if region:
+            self._select_combobox_option(page, "Région", region)
+        if levels:
+            try:
+                toggle = page.get_by_role("button", name=re.compile("Niveau", re.I))
+                toggle.click()
+                for level in levels:
+                    option = page.get_by_role("checkbox", name=re.compile(level, re.I))
+                    if not option.is_checked():
+                        option.check()
+                        self._rate_limit()
+                toggle.click()
+            except PlaywrightError:
+                self._logger.warning("Unable to set levels", extra={"levels": levels})
+
+    def _set_date_field(self, page: Page, label: str, value: str) -> None:
+        try:
+            control = page.get_by_label(label, exact=False)
+            control.click()
+            control.fill(value)
+            control.press("Enter")
+            self._rate_limit()
+        except PlaywrightError:
+            self._logger.warning("Unable to set date", extra={"field": label, "value": value})
 
     def _select_category(self, page: Page, category: str) -> None:
-        labels = {"H": "Hommes", "F": "Dames", "MIXTE": "Mixte"}
         try:
-            page.get_by_role("button", name="Catégorie").click()
-            page.get_by_role("option", name=labels.get(category, category)).click()
+            toggle = page.get_by_role("button", name=re.compile("Catégorie", re.I))
+            toggle.click()
+            labels = {"H": "Hommes", "F": "Dames", "MIXTE": "Mixte"}
+            label = labels.get(category.upper(), category)
+            option = page.get_by_role("option", name=re.compile(label, re.I))
+            option.click()
+            self._rate_limit()
         except PlaywrightError:
-            self.log.warning("Unable to select category %s", category)
+            self._logger.warning("Unable to select category", extra={"category": category})
 
-    def _set_date_range(self, page: Page, date_from: str, date_to: str) -> None:
+    def _select_combobox_option(self, page: Page, label: str, value: str) -> None:
         try:
-            page.get_by_label("Date de début").fill(date_from)
-            page.get_by_label("Date de fin").fill(date_to)
-            page.get_by_label("Date de fin").press("Enter")
+            toggle = page.get_by_role("button", name=re.compile(label, re.I))
+            toggle.click()
+            option = page.get_by_role("option", name=re.compile(value, re.I))
+            option.click()
+            self._rate_limit()
         except PlaywrightError:
-            self.log.warning("Unable to set date range")
+            self._logger.warning("Unable to select option", extra={"label": label, "value": value})
 
-    def _select_region(self, page: Page, region: str) -> None:
+    def _refresh_results(self, page: Page) -> None:
         try:
-            page.get_by_role("button", name="Région").click()
-            page.get_by_role("option", name=region).click()
+            apply_button = page.get_by_role("button", name=re.compile("Rechercher|Appliquer", re.I))
+            if apply_button.is_visible():
+                apply_button.click()
+                self._rate_limit()
         except PlaywrightError:
-            self.log.warning("Unable to select region %s", region)
+            pass
 
-    def _select_city(self, page: Page, city: str, radius: Optional[object]) -> None:
-        try:
-            page.get_by_label("Ville").fill(city)
-            page.get_by_label("Ville").press("Enter")
-            if radius:
-                page.get_by_label("Rayon").fill(str(radius))
-        except PlaywrightError:
-            self.log.warning("Unable to select city %s", city)
-
-    def _select_levels(self, page: Page, levels: Sequence[str]) -> None:
-        try:
-            page.get_by_role("button", name="Niveau").click()
-            for level in levels:
-                option = page.get_by_role("checkbox", name=level)
-                if option.is_checked():
-                    continue
-                option.check()
-            page.get_by_role("button", name="Niveau").click()
-        except PlaywrightError:
-            self.log.warning("Unable to select levels %s", levels)
-
-    def _collect_from_dom(self, page: Page, limit: int) -> List[Tournament]:
-        tournaments: List[Tournament] = []
-        seen_urls: set[str] = set()
-        while True:
+    # ------------------------------------------------------------------
+    # Collection helpers
+    # ------------------------------------------------------------------
+    def _collect_list_items(self, page: Page, limit: int) -> List[ScrapedTournament]:
+        items: List[ScrapedTournament] = []
+        retries = 0
+        while len(items) < limit:
             cards = page.locator("[data-testid='tournament-card']")
-            count = cards.count()
-            for index in range(count):
+            total = cards.count()
+            for index in range(total):
+                if len(items) >= limit:
+                    break
                 card = cards.nth(index)
-                url = card.get_by_role("link").first.get_attribute("href") or ""
-                if url in seen_urls:
+                try:
+                    tournament = self._parse_card(page, card)
+                except Exception as exc:  # pragma: no cover - defensive
+                    self._logger.warning("Failed to parse card", extra={"error": str(exc)})
                     continue
-                seen_urls.add(url)
-                tournament = self._build_tournament_from_card(card)
                 if tournament:
-                    tournaments.append(tournament)
-                if len(tournaments) >= limit:
-                    return tournaments
-            load_more = page.get_by_role("button", name="Charger plus")
+                    items.append(tournament)
+            if len(items) >= limit:
+                break
+            try:
+                load_more = page.get_by_role("button", name=re.compile("(Charger|Voir) plus", re.I))
+            except PlaywrightError:
+                break
             if load_more.is_visible():
                 load_more.click()
-                page.wait_for_load_state("networkidle", timeout=self.request_timeout)
-                time.sleep(random.uniform(0.3, 0.9))
+                self._rate_limit()
                 continue
-            break
-        return tournaments
+            retries += 1
+            if retries >= self.max_retries:
+                break
+        return items
 
-    def _build_tournament_from_card(self, card: Locator) -> Optional[Tournament]:
-        try:
-            link = card.get_by_role("link").first
-            href = link.get_attribute("href") or ""
-            title = link.inner_text().strip()
-            meta = card.inner_text()
-            dates = card.locator("[data-role='dates']").first.inner_text()
-        except PlaywrightError:
+    def _parse_card(self, page: Page, card: Locator) -> Optional[ScrapedTournament]:
+        link = card.get_by_role("link").first
+        detail_url = link.get_attribute("href") or ""
+        if not detail_url:
             return None
+        detail_url = urljoin(page.url, detail_url)
+        name = link.inner_text().strip()
+        meta_text = card.inner_text().strip()
+        category = self._extract_category(meta_text)
+        level = self._extract_level(meta_text)
 
-        raw = {
-            "url": href,
-            "title": title,
-            "meta": meta,
-            "dates": dates,
-        }
-        return self._build_tournament(raw)
+        return self._scrape_detail(page.context, detail_url, name=name, category=category, level=level)
+
+    def _scrape_detail(
+        self,
+        context: BrowserContext,
+        url: str,
+        *,
+        name: str,
+        category: str,
+        level: Optional[str],
+    ) -> Optional[ScrapedTournament]:
+        attempts = 0
+        while attempts < self.max_retries:
+            attempts += 1
+            detail_page = context.new_page()
+            try:
+                detail_page.goto(url, wait_until="domcontentloaded", timeout=self.request_timeout_ms)
+                detail_page.wait_for_load_state("networkidle", timeout=self.request_timeout_ms)
+                tournament = self._extract_detail(
+                    detail_page, url, name=name, category=category, level=level
+                )
+                detail_page.close()
+                if tournament:
+                    return tournament
+            except PlaywrightTimeoutError:
+                self._logger.warning("Detail page timeout", extra={"url": url, "attempt": attempts})
+            except PlaywrightError as exc:
+                self._logger.warning("Detail page error", extra={"url": url, "error": str(exc)})
+            finally:
+                if not detail_page.is_closed():
+                    detail_page.close()
+            self._rate_limit()
+        return None
+
+    def _extract_detail(
+        self,
+        page: Page,
+        url: str,
+        *,
+        name: str,
+        category: str,
+        level: Optional[str],
+    ) -> ScrapedTournament:
+        last_scraped_at = pendulum.now("Europe/Paris").to_iso8601_string()
+        clean_name = self._normalise_name(name or page.title())
+        header_name = self._safe_text(page.locator("h1")) or clean_name
+
+        info_map = self._extract_info_pairs(page)
+        start_date, end_date = self._extract_dates(page, info_map)
+        registration_deadline = self._normalise_date(info_map.get("Clôture des inscriptions"))
+        club_name = info_map.get("Club organisateur") or info_map.get("Club")
+        club_code = info_map.get("Code club")
+        organizer = info_map.get("Organisateur")
+        city = info_map.get("Ville") or self._extract_city_from_header(page)
+        address = info_map.get("Adresse")
+        surface = info_map.get("Surface")
+        indoor = info_map.get("Type") or info_map.get("Intérieur / Extérieur")
+        draw_size = self._safe_int(info_map.get("Tableau"))
+        price = self._safe_price(info_map.get("Tarif"))
+        status = info_map.get("Statut")
+        registration_url = self._extract_registration_url(page, url)
+        tournament_id = self._extract_tournament_id(page, url)
+        detail_level = level or self._extract_level(info_map.get("Niveau") or "")
+        if not detail_level:
+            detail_level = self._extract_level(info_map.get("Catégorie") or "")
+        detail_category = self._extract_category(info_map.get("Catégorie", "") or category)
+
+        return ScrapedTournament(
+            tournament_id=tournament_id,
+            name=header_name,
+            level=detail_level,
+            category=detail_category,
+            club_name=self._normalise_text(club_name),
+            club_code=self._normalise_text(club_code),
+            organizer=self._normalise_text(organizer),
+            city=self._normalise_text(city),
+            region=self._normalise_text(info_map.get("Région")),
+            address=self._normalise_text(address),
+            start_date=start_date,
+            end_date=end_date,
+            registration_deadline=registration_deadline,
+            surface=self._normalise_text(surface),
+            indoor_outdoor=self._normalise_text(indoor),
+            draw_size=draw_size,
+            price=price,
+            status=self._normalise_text(status),
+            detail_url=url,
+            registration_url=registration_url,
+            last_scraped_at=last_scraped_at,
+        )
+
+    # ------------------------------------------------------------------
+    # Extraction helpers
+    # ------------------------------------------------------------------
+    def _extract_info_pairs(self, page: Page) -> Dict[str, str]:
+        info: Dict[str, str] = {}
+        sections = page.locator("[data-testid='tournament-details']")
+        if sections.count() == 0:
+            sections = page.locator("section")
+        for section_index in range(sections.count()):
+            section = sections.nth(section_index)
+            dts = section.locator("xpath=.//dt")
+            dds = section.locator("xpath=.//dd")
+            total = min(dts.count(), dds.count())
+            for index in range(total):
+                try:
+                    key = dts.nth(index).inner_text().strip()
+                    value = dds.nth(index).inner_text().strip()
+                except PlaywrightError:
+                    continue
+                if key:
+                    info[key] = value
+        return info
+
+    def _extract_dates(self, page: Page, info_map: Dict[str, str]) -> tuple[str, str]:
+        raw_dates = info_map.get("Dates") or self._safe_text(page.locator("[data-testid='tournament-dates']"))
+        if raw_dates:
+            parts = [part.strip() for part in re.split(r"-|au", raw_dates) if part.strip()]
+            if len(parts) == 2:
+                start = self._normalise_date(parts[0])
+                end = self._normalise_date(parts[1])
+                if start and end:
+                    return start, end
+        fallback = self._normalise_date(info_map.get("Date de début"))
+        fallback_end = self._normalise_date(info_map.get("Date de fin"))
+        now_date = pendulum.now("Europe/Paris").to_date_string()
+        return fallback or now_date, fallback_end or fallback or now_date
+
+    def _extract_registration_url(self, page: Page, default: str) -> str:
+        try:
+            button = page.get_by_role("link", name=re.compile("(Inscription|S'inscrire)", re.I))
+            if button.is_visible():
+                href = button.get_attribute("href")
+                if href:
+                    return urljoin(page.url, href)
+        except PlaywrightError:
+            pass
+        return default
+
+    def _extract_tournament_id(self, page: Page, url: str) -> str:
+        try:
+            identifier = self._safe_text(page.locator("[data-testid='tournament-id']"))
+            if identifier:
+                return identifier
+        except PlaywrightError:
+            pass
+        match = re.search(r"(PAD[-_]\d+)", url)
+        if match:
+            return match.group(1)
+        match = re.search(r"/(\d{3,})", url)
+        if match:
+            return match.group(1)
+        return str(abs(hash(url)))
+
+    def _extract_category(self, text: str) -> str:
+        text = text.upper()
+        if "HOM" in text or "HOMME" in text or "MESSIEURS" in text:
+            return "H"
+        if "DAM" in text or "FEM" in text:
+            return "F"
+        if "MIX" in text:
+            return "MIXTE"
+        return "MIXTE"
+
+    def _extract_level(self, text: str) -> Optional[str]:
+        match = re.search(r"P\d{2,4}", text.upper())
+        return match.group(0) if match else None
+
+    def _extract_city_from_header(self, page: Page) -> Optional[str]:
+        subtitle = self._safe_text(page.locator("[data-testid='tournament-location']"))
+        if subtitle:
+            return subtitle
+        return None
 
     # ------------------------------------------------------------------
     # Normalisation helpers
     # ------------------------------------------------------------------
-    def _build_tournament(self, raw: Dict[str, object]) -> Optional[Tournament]:
-        try:
-            external_id = self._extract_external_id(raw)
-            start_date, end_date = self._extract_dates(raw)
-            title = str(raw.get("title") or raw.get("name") or "Tournoi TenUp").strip()
-            city = self._normalise_value(raw, ["city", "ville"])
-            postal_code = self._normalise_value(raw, ["postalCode", "code_postal", "postal_code"])
-            region = self._normalise_value(raw, ["region"])
-            club_name = self._normalise_value(raw, ["club", "clubName", "club_name"])
-            level = self._normalise_value(raw, ["level", "categorie"])
-            price = self._normalise_price(raw)
-            inscriptions_open = self._normalise_bool(raw.get("inscriptions_open") or raw.get("open"))
-            slots_total = self._normalise_int(raw.get("slots_total") or raw.get("slotsTotal"))
-            slots_taken = self._normalise_int(raw.get("slots_taken") or raw.get("slotsTaken"))
-            registration_url = self._extract_url(raw, "registration_url")
-            details_url = self._extract_url(raw, "details_url") or registration_url
+    def _normalise_name(self, name: str) -> str:
+        return self._normalise_text(name) or "Tournoi de padel"
 
-            tournament = Tournament(
-                external_id=external_id,
-                title=title,
-                discipline="PADEL",
-                category=self._normalise_category(raw),
-                level=level,
-                start_date=start_date,
-                end_date=end_date,
-                city=city,
-                postal_code=postal_code,
-                region=region,
-                club_name=club_name,
-                price=price,
-                registration_url=registration_url,
-                details_url=details_url,
-                inscriptions_open=inscriptions_open,
-                slots_total=slots_total,
-                slots_taken=slots_taken,
-                created_at=pendulum.now("Europe/Paris").to_iso8601_string(),
-            )
-            return tournament
-        except Exception as exc:  # pragma: no cover - defensive
-            self.log.warning("Failed to normalise tournament", error=str(exc), raw=raw)
-            return None
-
-    def _extract_external_id(self, raw: Dict[str, object]) -> str:
-        for key in ("external_id", "id", "uid"):
-            if raw.get(key):
-                return str(raw[key])
-        url = self._extract_url(raw, "details_url") or self._extract_url(raw, "registration_url")
-        return str(abs(hash(url)))
-
-    def _extract_dates(self, raw: Dict[str, object]) -> tuple[str, str]:
-        for key in ("start_date", "dateStart", "startDate"):
-            if raw.get(key):
-                start = pendulum.parse(str(raw[key]), strict=False)
-                break
-        else:
-            start = pendulum.now("Europe/Paris")
-        for key in ("end_date", "dateEnd", "endDate"):
-            if raw.get(key):
-                end = pendulum.parse(str(raw[key]), strict=False)
-                break
-        else:
-            end = start
-        return start.to_date_string(), end.to_date_string()
-
-    def _normalise_value(self, raw: Dict[str, object], keys: Sequence[str]) -> Optional[str]:
-        for key in keys:
-            if raw.get(key):
-                value = str(raw[key]).strip()
-                if value:
-                    return value
-        return None
-
-    def _normalise_category(self, raw: Dict[str, object]) -> str:
-        category = (self._normalise_value(raw, ["category", "sex", "genre"]) or "MIXTE").upper()
-        if category.startswith("H") or category in {"H", "HOMME", "HOMMES"}:
-            return "H"
-        if category.startswith("F") or category in {"F", "FEMME", "DAM", "DAMES"}:
-            return "F"
-        return "MIXTE"
-
-    def _normalise_price(self, raw: Dict[str, object]) -> Optional[float]:
-        value = raw.get("price") or raw.get("tarif")
-        if value in (None, ""):
-            return None
-        try:
-            return float(str(value).replace(",", "."))
-        except ValueError:
-            return None
-
-    def _normalise_bool(self, value: object) -> Optional[bool]:
+    def _normalise_text(self, value: Optional[str]) -> Optional[str]:
         if value is None:
             return None
-        if isinstance(value, bool):
-            return value
-        text = str(value).strip().lower()
-        if text in {"true", "1", "oui", "open"}:
-            return True
-        if text in {"false", "0", "non", "closed"}:
-            return False
-        return None
+        text = re.sub(r"\s+", " ", str(value)).strip()
+        return text or None
 
-    def _normalise_int(self, value: object) -> Optional[int]:
-        if value in (None, ""):
+    def _normalise_date(self, value: Optional[str]) -> Optional[str]:
+        if not value:
             return None
         try:
-            return int(value)
+            dt = pendulum.parse(str(value), strict=False, tz="Europe/Paris")
+            return dt.to_date_string()
+        except Exception:
+            return None
+
+    def _safe_text(self, locator: Locator) -> Optional[str]:
+        try:
+            if locator.count() == 0:
+                return None
+            text = locator.first.inner_text().strip()
+            return text or None
+        except PlaywrightError:
+            return None
+
+    def _safe_int(self, value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            digits = re.findall(r"\d+", value)
+            return int(digits[0]) if digits else None
         except (TypeError, ValueError):
             return None
 
-    def _extract_url(self, raw: Dict[str, object], key: str) -> str:
-        value = raw.get(key)
-        if value:
-            return str(value)
-        url = raw.get("url") or raw.get("link") or raw.get("href")
-        if url:
-            return str(url)
-        return self.base_url
+    def _safe_price(self, value: Optional[str]) -> Optional[float]:
+        if value is None:
+            return None
+        cleaned = value.replace("€", "").replace(",", ".")
+        digits = re.findall(r"\d+(?:\.\d+)?", cleaned)
+        if not digits:
+            return None
+        try:
+            return float(digits[0])
+        except ValueError:
+            return None
 
-    def _deduplicate(self, items: Iterable[Tournament]) -> List[Tournament]:
-        deduped: Dict[tuple[str, str], Tournament] = {}
-        for item in items:
-            key = (item.external_id, item.start_date)
-            if key not in deduped:
-                deduped[key] = item
-        return list(deduped.values())
+    # ------------------------------------------------------------------
+    # Misc helpers
+    # ------------------------------------------------------------------
+    def _rate_limit(self) -> None:
+        if not self.respect_rate_limit:
+            return
+        delay = random.uniform(*self.random_delay_range)
+        time.sleep(delay)
 
-
-def _load_config() -> Dict[str, object]:
-    if not CONFIG_PATH.exists():  # pragma: no cover - CLI usage
-        raise FileNotFoundError(f"Missing configuration file: {CONFIG_PATH}")
-    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
-        return json.load(fh)
-
-
-def _cli_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Scrape TenUp padel tournaments")
-    parser.add_argument("--category", action="append", help="Filtrer par catégorie (H, F, MIXTE)")
-    parser.add_argument("--from", dest="date_from", help="Date de début (YYYY-MM-DD)")
-    parser.add_argument("--to", dest="date_to", help="Date de fin (YYYY-MM-DD)")
-    parser.add_argument("--region", help="Filtrer par région")
-    parser.add_argument("--city", help="Filtrer par ville")
-    parser.add_argument("--radius-km", type=int, help="Rayon géographique en kilomètres")
-    parser.add_argument("--level", action="append", help="Filtrer par niveau (P25, P100, ...)")
-    parser.add_argument("--limit", type=int, default=200, help="Nombre maximum de tournois à récupérer")
-    parser.add_argument("--output", help="Fichier JSON de sortie")
-    parser.add_argument("--dry-run", action="store_true", help="Écrire un JSON de démonstration")
-    return parser.parse_args(argv)
-
-
-def _cli_main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - CLI entry point
-    args = _cli_args(argv)
-    config = _load_config()
-    scraper = TenUpScraper(config.get("tenup", {}))
-
-    categories = [token.upper() for token in (args.category or []) if token]
-    geo: Dict[str, object] = {}
-    if args.region:
-        geo["region"] = args.region
-    if args.city:
-        geo["city"] = args.city
-    if args.radius_km is not None:
-        geo["radius_km"] = args.radius_km
-    levels = [token.upper() for token in (args.level or []) if token]
-
-    today = pendulum.now("Europe/Paris")
-    start_date = args.date_from or today.to_date_string()
-    end_date = args.date_to or today.add(days=60).to_date_string()
-
-    tournaments = scraper.fetch_all(
-        categories=categories or ("H", "F", "MIXTE"),
-        date_from=start_date,
-        date_to=end_date,
-        geo=geo,
-        level=levels,
-        limit=args.limit,
-    )
-    if args.dry_run:
-        output_path = Path(args.output or "data/tenup-sample.json")
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = [tournament.model_dump() for tournament in tournaments]
-        output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-        print(f"Écriture de {len(tournaments)} tournois dans {output_path}")
-    else:
-        for tournament in tournaments:
-            print(json.dumps(tournament.model_dump(), ensure_ascii=False))
-    print(f"Total récupéré: {len(tournaments)}")
-    return 0
+    def _capture_debug_artifacts(self) -> None:
+        if not self._page or self._page.is_closed():
+            return
+        try:
+            content = self._page.content()
+        except PlaywrightError:
+            content = None
+        snapshot_dir = Path("data")
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        if content:
+            (snapshot_dir / "snapshot.html").write_text(content, encoding="utf-8")
+        if self._context:
+            try:
+                self._context.storage_state(path=str(snapshot_dir / "storage_state.json"))
+            except PlaywrightError:
+                pass
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - CLI entry point
-    return _cli_main(argv)
-
-
-if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    raise SystemExit(main())
+__all__ = ["ScrapedTournament", "TenUpScraper"]
 

--- a/services/tournament_store.py
+++ b/services/tournament_store.py
@@ -1,19 +1,18 @@
-"""Persistent storage utilities for TenUp tournaments."""
+"""Helpers to persist scraped tournaments to JSON and SQLite."""
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, List
-
-import json
+from typing import Iterable, Mapping
 
 from flask_sqlalchemy import SQLAlchemy
 
-from models.tournament import Tournament
+from services.tournament_store_models import TournamentRecord
 
 
-def ensure_directory(path: Path) -> None:
+def _ensure_directory(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -24,45 +23,43 @@ class UpsertResult:
     skipped: int = 0
 
     def as_dict(self) -> dict:
-        return {"inserted": self.inserted, "updated": self.updated, "skipped": self.skipped}
+        return {
+            "inserted": self.inserted,
+            "updated": self.updated,
+            "skipped": self.skipped,
+        }
 
 
 class TournamentStore:
-    """Service responsible for persisting tournaments to the database and JSON."""
+    """Persist tournaments to SQLite and JSON outputs."""
 
     def __init__(self, db: SQLAlchemy, json_path: Path) -> None:
         self._db = db
         self._json_path = json_path
-        ensure_directory(self._json_path)
+        _ensure_directory(self._json_path)
 
-    def upsert_many(self, records: Iterable[Tournament]) -> UpsertResult:
-        from services.tournament_store_models import TournamentRecord  # circular
-
+    def upsert_many(self, records: Iterable[Mapping[str, object]]) -> UpsertResult:
         session = self._db.session
         stats = UpsertResult()
         now = datetime.utcnow()
 
-        for entry in records:
-            key = {
-                "source": entry.source,
-                "external_id": entry.external_id,
-                "start_date": entry.start_date,
-            }
-            existing = session.query(TournamentRecord).filter_by(**key).one_or_none()
+        for payload in records:
+            data = dict(payload)
+            tournament_id = str(data["tournament_id"])
+            existing = (
+                session.query(TournamentRecord)
+                .filter(TournamentRecord.tournament_id == tournament_id)
+                .one_or_none()
+            )
             if existing is None:
-                instance = TournamentRecord.from_model(entry)
+                instance = TournamentRecord(**data)
                 instance.created_at = now
                 instance.updated_at = now
                 session.add(instance)
                 stats.inserted += 1
                 continue
 
-            payload = entry.model_dump(exclude={"source"})
-            changed = False
-            for field, value in payload.items():
-                if getattr(existing, field) != value:
-                    setattr(existing, field, value)
-                    changed = True
+            changed = existing.update_from_payload(data)
             if changed:
                 existing.updated_at = now
                 stats.updated += 1
@@ -74,18 +71,15 @@ class TournamentStore:
         return stats
 
     def _export_json(self) -> None:
-        from services.tournament_store_models import TournamentRecord  # circular
-
         session = self._db.session
-        rows: List[TournamentRecord] = (
-            session.query(TournamentRecord).order_by(TournamentRecord.start_date.asc()).all()
+        rows = session.query(TournamentRecord).order_by(TournamentRecord.start_date.asc()).all()
+        payload = [row.to_dict() for row in rows]
+        _ensure_directory(self._json_path)
+        self._json_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
         )
-        payload = {
-            "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
-            "source": "tenup",
-            "tournaments": [row.to_dict() for row in rows],
-        }
-        ensure_directory(self._json_path)
-        self._json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
+
+__all__ = ["TournamentStore", "UpsertResult"]
 

--- a/services/tournament_store_models.py
+++ b/services/tournament_store_models.py
@@ -1,96 +1,81 @@
-"""Database models used to persist TenUp tournaments."""
+"""SQLAlchemy models used to persist scraped tournaments."""
 from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Dict
 
-import pendulum
-
 from extensions import db
-from models.tournament import Tournament
 
 
 class TournamentRecord(db.Model):
     __tablename__ = "tournaments"
 
     id = db.Column(db.Integer, primary_key=True)
-    source = db.Column(db.String(32), nullable=False, index=True)
-    external_id = db.Column(db.String(128), nullable=False, index=True)
-    title = db.Column(db.String(512), nullable=False)
-    discipline = db.Column(db.String(32), nullable=False)
+    tournament_id = db.Column(db.String(128), unique=True, nullable=False, index=True)
+    name = db.Column(db.String(512), nullable=False)
+    level = db.Column(db.String(16))
     category = db.Column(db.String(16), nullable=False, index=True)
-    level = db.Column(db.String(32))
+    club_name = db.Column(db.String(256))
+    club_code = db.Column(db.String(64))
+    organizer = db.Column(db.String(256))
+    city = db.Column(db.String(128), index=True)
+    region = db.Column(db.String(128), index=True)
+    address = db.Column(db.String(512))
     start_date = db.Column(db.String(10), nullable=False, index=True)
     end_date = db.Column(db.String(10), nullable=False)
-    city = db.Column(db.String(128))
-    postal_code = db.Column(db.String(32))
-    region = db.Column(db.String(128), index=True)
-    club_name = db.Column(db.String(256))
+    registration_deadline = db.Column(db.String(10))
+    surface = db.Column(db.String(64))
+    indoor_outdoor = db.Column(db.String(64))
+    draw_size = db.Column(db.Integer)
     price = db.Column(db.Float)
-    registration_url = db.Column(db.String(512), nullable=False)
-    details_url = db.Column(db.String(512), nullable=False)
-    inscriptions_open = db.Column(db.Boolean)
-    slots_total = db.Column(db.Integer)
-    slots_taken = db.Column(db.Integer)
+    status = db.Column(db.String(64))
+    detail_url = db.Column(db.String(512), nullable=False)
+    registration_url = db.Column(db.String(512))
+    last_scraped_at = db.Column(db.String(32), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
     )
 
-    __table_args__ = (
-        db.UniqueConstraint(
-            "source", "external_id", "start_date", name="uq_tournaments_source_external_start"
-        ),
-    )
-
-    @classmethod
-    def from_model(cls, model: Tournament) -> "TournamentRecord":
-        created_at = pendulum.parse(model.created_at, strict=False).naive()
-        instance = cls(
-            source=model.source,
-            external_id=model.external_id,
-            title=model.title,
-            discipline=model.discipline,
-            category=model.category,
-            level=model.level,
-            start_date=model.start_date,
-            end_date=model.end_date,
-            city=model.city,
-            postal_code=model.postal_code,
-            region=model.region,
-            club_name=model.club_name,
-            price=model.price,
-            registration_url=str(model.registration_url),
-            details_url=str(model.details_url),
-            inscriptions_open=model.inscriptions_open,
-            slots_total=model.slots_total,
-            slots_taken=model.slots_taken,
-            created_at=created_at,
-            updated_at=created_at,
-        )
-        return instance
+    def update_from_payload(self, payload: Dict[str, Any]) -> bool:
+        changed = False
+        for field, value in payload.items():
+            if field in {"id", "created_at", "updated_at"}:
+                continue
+            if getattr(self, field) != value:
+                setattr(self, field, value)
+                changed = True
+        return changed
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "id": self.id,
-            "source": self.source,
-            "external_id": self.external_id,
-            "title": self.title,
-            "discipline": self.discipline,
-            "category": self.category,
+            "tournament_id": self.tournament_id,
+            "name": self.name,
+            "title": self.name,
             "level": self.level,
+            "category": self.category,
+            "club_name": self.club_name,
+            "club_code": self.club_code,
+            "organizer": self.organizer,
+            "city": self.city,
+            "address": self.address,
+            "region": self.region,
             "start_date": self.start_date,
             "end_date": self.end_date,
-            "city": self.city,
-            "postal_code": self.postal_code,
-            "region": self.region,
-            "club_name": self.club_name,
+            "registration_deadline": self.registration_deadline,
+            "surface": self.surface,
+            "indoor_outdoor": self.indoor_outdoor,
+            "draw_size": self.draw_size,
             "price": self.price,
+            "status": self.status,
+            "detail_url": self.detail_url,
+            "details_url": self.detail_url,
             "registration_url": self.registration_url,
-            "details_url": self.details_url,
-            "inscriptions_open": self.inscriptions_open,
-            "slots_total": self.slots_total,
-            "slots_taken": self.slots_taken,
-            "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
+            "last_scraped_at": self.last_scraped_at,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+__all__ = ["TournamentRecord"]
+


### PR DESCRIPTION
## Summary
- replace the TenUp scraper with a Playwright-only implementation that normalises tournament data and captures debug artefacts
- update scraping services to expose a new `scrape_all` entry point, persist results via the revised tournament store, and refresh CLI handling
- align storage with the new schema, export flat JSON arrays, and streamline the macOS helper script

## Testing
- python -m compileall services scrapers

------
https://chatgpt.com/codex/tasks/task_e_68e2ec07aee08321bcd3208dd3af4d6e