### PR TITLE
Refactor TenUp scraping workflow for new UI

### DIFF
--- a/scrapers/tenup.py
+++ b/scrapers/tenup.py
@@ -1,606 +1,273 @@
-"""Playwright-based scraper for TenUp padel tournaments."""
+"""Playwright helpers dedicated to the TenUp tournament search UI."""
 from __future__ import annotations
 
 import logging
 import random
 import re
 import time
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence
-from urllib.parse import urljoin
+from datetime import datetime
+from typing import Dict, List, Optional
 
-import pendulum
-from playwright.sync_api import (  # type: ignore[import-untyped]
-    Browser,
-    BrowserContext,
-    Error as PlaywrightError,
-    Locator,
-    Page,
-    TimeoutError as PlaywrightTimeoutError,
-    sync_playwright,
-)
+from playwright.sync_api import Locator, Page, expect
+
+LOGGER = logging.getLogger("scrapers.tenup")
+TENUP_URL = "https://tenup.fft.fr/recherche/tournois"
 
 
-_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-)
+def _pause() -> None:
+    """Sleep a short, slightly random delay to mimic human interaction."""
+
+    time.sleep(random.uniform(1.2, 2.2))
 
 
-@dataclass(slots=True)
-class ScrapedTournament:
-    """Normalised structure returned by :class:`TenUpScraper`."""
+def click_retry(locator: Locator, attempts: int = 3, timeout: float = 8000) -> None:
+    """Click a locator with retries in case the UI is lagging."""
 
-    tournament_id: str
-    name: str
-    level: Optional[str]
-    category: str
-    club_name: Optional[str]
-    club_code: Optional[str]
-    organizer: Optional[str]
-    city: Optional[str]
-    region: Optional[str]
-    address: Optional[str]
-    start_date: str
-    end_date: str
-    registration_deadline: Optional[str]
-    surface: Optional[str]
-    indoor_outdoor: Optional[str]
-    draw_size: Optional[int]
-    price: Optional[float]
-    status: Optional[str]
-    detail_url: str
-    registration_url: Optional[str]
-    last_scraped_at: str
-
-    def asdict(self) -> Dict[str, object]:
-        return {
-            "tournament_id": self.tournament_id,
-            "name": self.name,
-            "level": self.level,
-            "category": self.category,
-            "club_name": self.club_name,
-            "club_code": self.club_code,
-            "organizer": self.organizer,
-            "city": self.city,
-            "region": self.region,
-            "address": self.address,
-            "start_date": self.start_date,
-            "end_date": self.end_date,
-            "registration_deadline": self.registration_deadline,
-            "surface": self.surface,
-            "indoor_outdoor": self.indoor_outdoor,
-            "draw_size": self.draw_size,
-            "price": self.price,
-            "status": self.status,
-            "detail_url": self.detail_url,
-            "registration_url": self.registration_url,
-            "last_scraped_at": self.last_scraped_at,
-        }
-
-
-class TenUpScraper:
-    """Scrape the TenUp tournament catalogue via Playwright only."""
-
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        headless: bool = True,
-        request_timeout_ms: int = 30000,
-        respect_rate_limit: bool = True,
-        log_path: Optional[Path] = None,
-        random_delay_range: tuple[float, float] = (1.2, 2.0),
-        max_retries: int = 3,
-    ) -> None:
-        self.base_url = base_url
-        self.headless = headless
-        self.request_timeout_ms = request_timeout_ms
-        self.respect_rate_limit = respect_rate_limit
-        self.random_delay_range = random_delay_range
-        self.max_retries = max_retries
-        self._logger = logging.getLogger("scrapers.tenup")
-        self._log_path = Path(log_path) if log_path else None
-        if self._log_path:
-            self._log_path.parent.mkdir(parents=True, exist_ok=True)
-            handler = logging.FileHandler(self._log_path, encoding="utf-8")
-            handler.setLevel(logging.INFO)
-            formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
-            handler.setFormatter(formatter)
-            if not any(isinstance(h, logging.FileHandler) and h.baseFilename == handler.baseFilename for h in self._logger.handlers):
-                self._logger.addHandler(handler)
-        self._logger.setLevel(logging.INFO)
-        self._page: Optional[Page] = None
-        self._context: Optional[BrowserContext] = None
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-    def scrape(
-        self,
-        *,
-        region: Optional[str],
-        date_from: str,
-        date_to: str,
-        categories: Iterable[str],
-        levels: Sequence[str],
-        limit: int,
-    ) -> List[ScrapedTournament]:
-        """Return a normalised list of tournaments matching the filters."""
-
-        self._logger.info(
-            "Starting TenUp scrape",
-            extra={
-                "region": region,
-                "date_from": date_from,
-                "date_to": date_to,
-                "categories": list(categories),
-                "levels": list(levels),
-                "limit": limit,
-            },
-        )
+    last_error: Optional[Exception] = None
+    for attempt in range(attempts):
         try:
-            with sync_playwright() as playwright:
-                browser = self._launch_browser(playwright)
-                try:
-                    context = self._new_context(browser)
-                    self._context = context
-                    page = context.new_page()
-                    self._page = page
-                    tournaments = self._scrape_with_page(
-                        page,
-                        region=region,
-                        date_from=date_from,
-                        date_to=date_to,
-                        categories=list(categories),
-                        levels=list(levels),
-                        limit=limit,
-                    )
-                finally:
-                    self._page = None
-                    if self._context is not None:
-                        self._context.close()
-                        self._context = None
-                    browser.close()
-        except Exception:
-            self._capture_debug_artifacts()
-            raise
+            locator.wait_for(state="visible", timeout=timeout)
+            locator.click()
+            _pause()
+            return
+        except Exception as exc:  # pragma: no cover - defensive against flaky UI
+            last_error = exc
+            if attempt == attempts - 1:
+                raise
+            _pause()
+    if last_error:  # pragma: no cover - diagnostic help
+        raise last_error
 
-        deduped: Dict[str, ScrapedTournament] = {}
-        for item in tournaments:
-            deduped[item.tournament_id] = item
-        sorted_items = sorted(deduped.values(), key=lambda item: item.start_date or "")
-        self._logger.info("Scrape completed", extra={"count": len(sorted_items)})
-        return sorted_items[:limit]
 
-    # ------------------------------------------------------------------
-    # Browser helpers
-    # ------------------------------------------------------------------
-    def _launch_browser(self, playwright) -> Browser:
-        return playwright.chromium.launch(headless=self.headless)
+def accept_cookies(page: Page) -> None:
+    """Dismiss the cookie banner if it shows up."""
 
-    def _new_context(self, browser: Browser) -> BrowserContext:
-        context = browser.new_context(
-            locale="fr-FR",
-            timezone_id="Europe/Paris",
-            user_agent=_USER_AGENT,
-            viewport={"width": 1440, "height": 900},
-        )
-        return context
+    try:
+        banner = page.get_by_role("button", name=re.compile("accepter", re.I))
+        if banner.count():
+            banner.first.click()
+            _pause()
+    except Exception:  # pragma: no cover - banner might not exist
+        return
 
-    def _scrape_with_page(
-        self,
-        page: Page,
-        *,
-        region: Optional[str],
-        date_from: str,
-        date_to: str,
-        categories: Sequence[str],
-        levels: Sequence[str],
-        limit: int,
-    ) -> List[ScrapedTournament]:
-        self._goto_home(page)
-        self._accept_cookies(page)
-        self._apply_filters(page, region=region, date_from=date_from, date_to=date_to, levels=levels)
 
-        tournaments: List[ScrapedTournament] = []
-        seen_urls: set[str] = set()
-        for category in [token.upper() for token in (categories or ("MIXTE",))]:
-            self._select_category(page, category)
-            self._refresh_results(page)
-            items = self._collect_list_items(page, limit)
-            for summary in items:
-                if summary.detail_url in seen_urls:
-                    continue
-                seen_urls.add(summary.detail_url)
-                tournaments.append(summary)
-                if len(tournaments) >= limit:
-                    break
-            if len(tournaments) >= limit:
-                break
-        return tournaments
+def _pattern_from_text(value: str) -> re.Pattern[str]:
+    """Build a lenient regex that tolerates accents and spacing variations."""
 
-    # ------------------------------------------------------------------
-    # Navigation helpers
-    # ------------------------------------------------------------------
-    def _goto_home(self, page: Page) -> None:
-        page.goto(self.base_url, wait_until="domcontentloaded", timeout=self.request_timeout_ms)
-        page.wait_for_load_state("networkidle", timeout=self.request_timeout_ms)
+    pieces: List[str] = []
+    for char in value.strip():
+        if char.isspace():
+            pieces.append(r"\s+")
+            continue
+        if char in {"'", "\"", "`", "’"}:
+            pieces.append("[’'`\"]?")
+            continue
+        pieces.append(re.escape(char))
+    pattern = "".join(pieces)
+    if not pattern:
+        pattern = ".*"
+    return re.compile(pattern, re.I)
 
-    def _accept_cookies(self, page: Page) -> None:
+
+def select_ligue_paca_alpes_maritimes(
+    page: Page,
+    region: str = "PROVENCE ALPES COTE D’AZUR",
+    committee: str = "ALPES MARITIMES",
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Navigate through the Ligue/Comité selector with robust locators."""
+
+    log = logger or LOGGER
+    log.info("Selecting Ligue %s", region)
+    click_retry(page.get_by_role("tab", name=re.compile(r"^Ligue$", re.I)))
+
+    button = page.get_by_role("button", name=re.compile(r"ligue.*joue", re.I))
+    if not button.count():
+        button = page.get_by_placeholder(re.compile(r"ligue", re.I)).first
+    click_retry(button)
+
+    region_pattern = _pattern_from_text(region)
+    click_retry(page.get_by_role("checkbox", name=region_pattern))
+    click_retry(page.get_by_role("button", name=re.compile(r"^SUIVANT$", re.I)))
+
+    log.info("Selecting Comité %s", committee)
+    committee_pattern = _pattern_from_text(committee)
+    click_retry(page.get_by_role("button", name=committee_pattern))
+    click_retry(page.get_by_role("button", name=re.compile(r"^VALIDER$", re.I)))
+
+
+def select_discipline_padel(page: Page, logger: Optional[logging.Logger] = None) -> None:
+    """Switch the discipline from Tennis to Padel via the popover menu."""
+
+    log = logger or LOGGER
+    log.info("Selecting Padel discipline")
+    click_retry(page.get_by_role("button", name=re.compile(r"^Tennis$", re.I)))
+    click_retry(page.get_by_role("button", name=re.compile(r"^Padel$", re.I)))
+    click_retry(page.get_by_role("button", name=re.compile(r"^APPLIQUER$", re.I)))
+
+
+def search_and_sort(page: Page, logger: Optional[logging.Logger] = None) -> None:
+    """Trigger the search and try to sort the result list by start date."""
+
+    log = logger or LOGGER
+    log.info("Launching search")
+    click_retry(page.get_by_role("button", name=re.compile(r"^RECHERCHER$", re.I)))
+    page.wait_for_load_state("networkidle")
+
+    try:
+        tri_trigger = page.get_by_text(re.compile(r"^Tri par ", re.I)).first
+        click_retry(tri_trigger)
+        click_retry(page.get_by_role("menuitem", name=re.compile(r"date de début", re.I)))
+    except Exception:
+        log.warning("Sort by start date failed; will sort client-side.")
+    else:
         try:
-            button = page.get_by_role("button", name=re.compile("accepter", re.I))
-            if button.is_visible():
-                button.click()
-                self._rate_limit()
-        except PlaywrightError:
-            self._logger.debug("Cookie banner not displayed")
-
-    def _apply_filters(
-        self,
-        page: Page,
-        *,
-        region: Optional[str],
-        date_from: str,
-        date_to: str,
-        levels: Sequence[str],
-    ) -> None:
-        self._set_date_field(page, "Date de début", date_from)
-        self._set_date_field(page, "Date de fin", date_to)
-        if region:
-            self._select_combobox_option(page, "Région", region)
-        if levels:
-            try:
-                toggle = page.get_by_role("button", name=re.compile("Niveau", re.I))
-                toggle.click()
-                for level in levels:
-                    option = page.get_by_role("checkbox", name=re.compile(level, re.I))
-                    if not option.is_checked():
-                        option.check()
-                        self._rate_limit()
-                toggle.click()
-            except PlaywrightError:
-                self._logger.warning("Unable to set levels", extra={"levels": levels})
-
-    def _set_date_field(self, page: Page, label: str, value: str) -> None:
-        try:
-            control = page.get_by_label(label, exact=False)
-            control.click()
-            control.fill(value)
-            control.press("Enter")
-            self._rate_limit()
-        except PlaywrightError:
-            self._logger.warning("Unable to set date", extra={"field": label, "value": value})
-
-    def _select_category(self, page: Page, category: str) -> None:
-        try:
-            toggle = page.get_by_role("button", name=re.compile("Catégorie", re.I))
-            toggle.click()
-            labels = {"H": "Hommes", "F": "Dames", "MIXTE": "Mixte"}
-            label = labels.get(category.upper(), category)
-            option = page.get_by_role("option", name=re.compile(label, re.I))
-            option.click()
-            self._rate_limit()
-        except PlaywrightError:
-            self._logger.warning("Unable to select category", extra={"category": category})
-
-    def _select_combobox_option(self, page: Page, label: str, value: str) -> None:
-        try:
-            toggle = page.get_by_role("button", name=re.compile(label, re.I))
-            toggle.click()
-            option = page.get_by_role("option", name=re.compile(value, re.I))
-            option.click()
-            self._rate_limit()
-        except PlaywrightError:
-            self._logger.warning("Unable to select option", extra={"label": label, "value": value})
-
-    def _refresh_results(self, page: Page) -> None:
-        try:
-            apply_button = page.get_by_role("button", name=re.compile("Rechercher|Appliquer", re.I))
-            if apply_button.is_visible():
-                apply_button.click()
-                self._rate_limit()
-        except PlaywrightError:
+            expect(page.get_by_text(re.compile(r"date de début", re.I))).to_be_visible(timeout=8000)
+        except Exception:  # pragma: no cover - best effort expectation
             pass
 
-    # ------------------------------------------------------------------
-    # Collection helpers
-    # ------------------------------------------------------------------
-    def _collect_list_items(self, page: Page, limit: int) -> List[ScrapedTournament]:
-        items: List[ScrapedTournament] = []
-        retries = 0
-        while len(items) < limit:
-            cards = page.locator("[data-testid='tournament-card']")
-            total = cards.count()
-            for index in range(total):
-                if len(items) >= limit:
-                    break
-                card = cards.nth(index)
-                try:
-                    tournament = self._parse_card(page, card)
-                except Exception as exc:  # pragma: no cover - defensive
-                    self._logger.warning("Failed to parse card", extra={"error": str(exc)})
-                    continue
-                if tournament:
-                    items.append(tournament)
+
+WARNING_MESSAGE = "WARNING Using client-side date filter."
+
+
+def warn_client_side_date_filter(logger: Optional[logging.Logger] = None) -> None:
+    """Log the warning about bypassing the TenUp date picker."""
+
+    log = logger or LOGGER
+    log.warning(WARNING_MESSAGE)
+
+
+FR_MONTHS = {
+    "janv": 1,
+    "jan.": 1,
+    "févr": 2,
+    "fév.": 2,
+    "fevr": 2,
+    "mars": 3,
+    "avr.": 4,
+    "avr": 4,
+    "mai": 5,
+    "juin": 6,
+    "juil": 7,
+    "juil.": 7,
+    "août": 8,
+    "aout": 8,
+    "sept": 9,
+    "sep.": 9,
+    "oct": 10,
+    "oct.": 10,
+    "nov": 11,
+    "déc": 12,
+    "déc.": 12,
+    "dec": 12,
+    "dec.": 12,
+}
+
+
+def _date_fr_to_iso(value: str) -> Optional[str]:
+    match = re.search(r"(\d{1,2})\s+([a-zéû\.]+)\s+(\d{4})", value.lower())
+    if not match:
+        return None
+    day = int(match.group(1))
+    month_token = match.group(2).replace("é", "e").replace("û", "u")
+    month = FR_MONTHS.get(month_token, None)
+    if not month:
+        return None
+    year = int(match.group(3))
+    try:
+        return datetime(year, month, day).strftime("%Y-%m-%d")
+    except ValueError:  # pragma: no cover - guard against invalid dates
+        return None
+
+
+def extract_cards(page: Page, limit: int = 500) -> List[Dict[str, Optional[str]]]:
+    """Scroll through the TenUp results and normalise the visible cards."""
+
+    items: List[Dict[str, Optional[str]]] = []
+    seen = -1
+    while len(items) < limit and len(items) != seen:
+        seen = len(items)
+        cards = page.locator(
+            "article, div[data-testid='event-card'], li:has(div:has-text('DM')), div:has-text('DM /')"
+        ).all()
+        for card in cards:
             if len(items) >= limit:
                 break
             try:
-                load_more = page.get_by_role("button", name=re.compile("(Charger|Voir) plus", re.I))
-            except PlaywrightError:
-                break
-            if load_more.is_visible():
-                load_more.click()
-                self._rate_limit()
+                text = card.inner_text()
+            except Exception:  # pragma: no cover - skip faulty cards
                 continue
-            retries += 1
-            if retries >= self.max_retries:
-                break
-        return items
 
-    def _parse_card(self, page: Page, card: Locator) -> Optional[ScrapedTournament]:
-        link = card.get_by_role("link").first
-        detail_url = link.get_attribute("href") or ""
-        if not detail_url:
-            return None
-        detail_url = urljoin(page.url, detail_url)
-        name = link.inner_text().strip()
-        meta_text = card.inner_text().strip()
-        category = self._extract_category(meta_text)
-        level = self._extract_level(meta_text)
-
-        return self._scrape_detail(page.context, detail_url, name=name, category=category, level=level)
-
-    def _scrape_detail(
-        self,
-        context: BrowserContext,
-        url: str,
-        *,
-        name: str,
-        category: str,
-        level: Optional[str],
-    ) -> Optional[ScrapedTournament]:
-        attempts = 0
-        while attempts < self.max_retries:
-            attempts += 1
-            detail_page = context.new_page()
             try:
-                detail_page.goto(url, wait_until="domcontentloaded", timeout=self.request_timeout_ms)
-                detail_page.wait_for_load_state("networkidle", timeout=self.request_timeout_ms)
-                tournament = self._extract_detail(
-                    detail_page, url, name=name, category=category, level=level
-                )
-                detail_page.close()
-                if tournament:
-                    return tournament
-            except PlaywrightTimeoutError:
-                self._logger.warning("Detail page timeout", extra={"url": url, "attempt": attempts})
-            except PlaywrightError as exc:
-                self._logger.warning("Detail page error", extra={"url": url, "error": str(exc)})
-            finally:
-                if not detail_page.is_closed():
-                    detail_page.close()
-            self._rate_limit()
-        return None
+                heading = card.get_by_role("heading")
+                if heading.count():
+                    name = heading.first.inner_text().strip()
+                else:
+                    name = text.splitlines()[0].strip()
+            except Exception:
+                name = text.splitlines()[0].strip() if text else ""
+            if not name:
+                continue
 
-    def _extract_detail(
-        self,
-        page: Page,
-        url: str,
-        *,
-        name: str,
-        category: str,
-        level: Optional[str],
-    ) -> ScrapedTournament:
-        last_scraped_at = pendulum.now("Europe/Paris").to_iso8601_string()
-        clean_name = self._normalise_name(name or page.title())
-        header_name = self._safe_text(page.locator("h1")) or clean_name
+            raw_dates = re.findall(r"\d{1,2}\s+[a-zéû\.]+\.?\s+\d{4}", text.lower())
+            start_iso = _date_fr_to_iso(raw_dates[0]) if raw_dates else None
+            end_iso = _date_fr_to_iso(raw_dates[1]) if len(raw_dates) > 1 else start_iso
 
-        info_map = self._extract_info_pairs(page)
-        start_date, end_date = self._extract_dates(page, info_map)
-        registration_deadline = self._normalise_date(info_map.get("Clôture des inscriptions"))
-        club_name = info_map.get("Club organisateur") or info_map.get("Club")
-        club_code = info_map.get("Code club")
-        organizer = info_map.get("Organisateur")
-        city = info_map.get("Ville") or self._extract_city_from_header(page)
-        address = info_map.get("Adresse")
-        surface = info_map.get("Surface")
-        indoor = info_map.get("Type") or info_map.get("Intérieur / Extérieur")
-        draw_size = self._safe_int(info_map.get("Tableau"))
-        price = self._safe_price(info_map.get("Tarif"))
-        status = info_map.get("Statut")
-        registration_url = self._extract_registration_url(page, url)
-        tournament_id = self._extract_tournament_id(page, url)
-        detail_level = level or self._extract_level(info_map.get("Niveau") or "")
-        if not detail_level:
-            detail_level = self._extract_level(info_map.get("Catégorie") or "")
-        detail_category = self._extract_category(info_map.get("Catégorie", "") or category)
+            level_match = re.search(r"\bP(100|250|500|1000|1500|2000)\b", text)
+            category_match = re.search(r"\bDM(?:\s*/\s*DX)?|\bSM\s*/\s*SD|\bDX\b", text, re.I)
+            level = level_match.group(0) if level_match else None
+            category = (
+                category_match.group(0).upper().replace(" ", "") if category_match else None
+            )
 
-        return ScrapedTournament(
-            tournament_id=tournament_id,
-            name=header_name,
-            level=detail_level,
-            category=detail_category,
-            club_name=self._normalise_text(club_name),
-            club_code=self._normalise_text(club_code),
-            organizer=self._normalise_text(organizer),
-            city=self._normalise_text(city),
-            region=self._normalise_text(info_map.get("Région")),
-            address=self._normalise_text(address),
-            start_date=start_date,
-            end_date=end_date,
-            registration_deadline=registration_deadline,
-            surface=self._normalise_text(surface),
-            indoor_outdoor=self._normalise_text(indoor),
-            draw_size=draw_size,
-            price=price,
-            status=self._normalise_text(status),
-            detail_url=url,
-            registration_url=registration_url,
-            last_scraped_at=last_scraped_at,
-        )
+            location_line = ""
+            for line in text.splitlines():
+                if "," in line:
+                    location_line = line.strip()
+                    break
+            club_name: Optional[str] = None
+            city: Optional[str] = None
+            if location_line:
+                parts = [segment.strip() for segment in location_line.split(",")]
+                if len(parts) > 1:
+                    club_name = ", ".join(parts[:-1])
+                    city = parts[-1]
+                else:
+                    club_name = parts[0]
+                    city = None
 
-    # ------------------------------------------------------------------
-    # Extraction helpers
-    # ------------------------------------------------------------------
-    def _extract_info_pairs(self, page: Page) -> Dict[str, str]:
-        info: Dict[str, str] = {}
-        sections = page.locator("[data-testid='tournament-details']")
-        if sections.count() == 0:
-            sections = page.locator("section")
-        for section_index in range(sections.count()):
-            section = sections.nth(section_index)
-            dts = section.locator("xpath=.//dt")
-            dds = section.locator("xpath=.//dd")
-            total = min(dts.count(), dds.count())
-            for index in range(total):
-                try:
-                    key = dts.nth(index).inner_text().strip()
-                    value = dds.nth(index).inner_text().strip()
-                except PlaywrightError:
-                    continue
-                if key:
-                    info[key] = value
-        return info
+            tournament_id = re.sub(
+                r"\W+", "-", f"{name}-{start_iso or ''}-{end_iso or ''}"
+            ).strip("-").lower()
+            if not tournament_id:
+                continue
 
-    def _extract_dates(self, page: Page, info_map: Dict[str, str]) -> tuple[str, str]:
-        raw_dates = info_map.get("Dates") or self._safe_text(page.locator("[data-testid='tournament-dates']"))
-        if raw_dates:
-            parts = [part.strip() for part in re.split(r"-|au", raw_dates) if part.strip()]
-            if len(parts) == 2:
-                start = self._normalise_date(parts[0])
-                end = self._normalise_date(parts[1])
-                if start and end:
-                    return start, end
-        fallback = self._normalise_date(info_map.get("Date de début"))
-        fallback_end = self._normalise_date(info_map.get("Date de fin"))
-        now_date = pendulum.now("Europe/Paris").to_date_string()
-        return fallback or now_date, fallback_end or fallback or now_date
-
-    def _extract_registration_url(self, page: Page, default: str) -> str:
-        try:
-            button = page.get_by_role("link", name=re.compile("(Inscription|S'inscrire)", re.I))
-            if button.is_visible():
-                href = button.get_attribute("href")
-                if href:
-                    return urljoin(page.url, href)
-        except PlaywrightError:
-            pass
-        return default
-
-    def _extract_tournament_id(self, page: Page, url: str) -> str:
-        try:
-            identifier = self._safe_text(page.locator("[data-testid='tournament-id']"))
-            if identifier:
-                return identifier
-        except PlaywrightError:
-            pass
-        match = re.search(r"(PAD[-_]\d+)", url)
-        if match:
-            return match.group(1)
-        match = re.search(r"/(\d{3,})", url)
-        if match:
-            return match.group(1)
-        return str(abs(hash(url)))
-
-    def _extract_category(self, text: str) -> str:
-        text = text.upper()
-        if "HOM" in text or "HOMME" in text or "MESSIEURS" in text:
-            return "H"
-        if "DAM" in text or "FEM" in text:
-            return "F"
-        if "MIX" in text:
-            return "MIXTE"
-        return "MIXTE"
-
-    def _extract_level(self, text: str) -> Optional[str]:
-        match = re.search(r"P\d{2,4}", text.upper())
-        return match.group(0) if match else None
-
-    def _extract_city_from_header(self, page: Page) -> Optional[str]:
-        subtitle = self._safe_text(page.locator("[data-testid='tournament-location']"))
-        if subtitle:
-            return subtitle
-        return None
-
-    # ------------------------------------------------------------------
-    # Normalisation helpers
-    # ------------------------------------------------------------------
-    def _normalise_name(self, name: str) -> str:
-        return self._normalise_text(name) or "Tournoi de padel"
-
-    def _normalise_text(self, value: Optional[str]) -> Optional[str]:
-        if value is None:
-            return None
-        text = re.sub(r"\s+", " ", str(value)).strip()
-        return text or None
-
-    def _normalise_date(self, value: Optional[str]) -> Optional[str]:
-        if not value:
-            return None
-        try:
-            dt = pendulum.parse(str(value), strict=False, tz="Europe/Paris")
-            return dt.to_date_string()
-        except Exception:
-            return None
-
-    def _safe_text(self, locator: Locator) -> Optional[str]:
-        try:
-            if locator.count() == 0:
-                return None
-            text = locator.first.inner_text().strip()
-            return text or None
-        except PlaywrightError:
-            return None
-
-    def _safe_int(self, value: Optional[str]) -> Optional[int]:
-        if value is None:
-            return None
-        try:
-            digits = re.findall(r"\d+", value)
-            return int(digits[0]) if digits else None
-        except (TypeError, ValueError):
-            return None
-
-    def _safe_price(self, value: Optional[str]) -> Optional[float]:
-        if value is None:
-            return None
-        cleaned = value.replace("€", "").replace(",", ".")
-        digits = re.findall(r"\d+(?:\.\d+)?", cleaned)
-        if not digits:
-            return None
-        try:
-            return float(digits[0])
-        except ValueError:
-            return None
-
-    # ------------------------------------------------------------------
-    # Misc helpers
-    # ------------------------------------------------------------------
-    def _rate_limit(self) -> None:
-        if not self.respect_rate_limit:
-            return
-        delay = random.uniform(*self.random_delay_range)
-        time.sleep(delay)
-
-    def _capture_debug_artifacts(self) -> None:
-        if not self._page or self._page.is_closed():
-            return
-        try:
-            content = self._page.content()
-        except PlaywrightError:
-            content = None
-        snapshot_dir = Path("data")
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        if content:
-            (snapshot_dir / "snapshot.html").write_text(content, encoding="utf-8")
-        if self._context:
-            try:
-                self._context.storage_state(path=str(snapshot_dir / "storage_state.json"))
-            except PlaywrightError:
-                pass
+            items.append(
+                {
+                    "tournament_id": tournament_id,
+                    "name": name,
+                    "level": level,
+                    "category": category,
+                    "club_name": club_name,
+                    "city": city,
+                    "start_date": start_iso,
+                    "end_date": end_iso,
+                    "detail_url": None,
+                    "registration_url": None,
+                }
+            )
+        page.mouse.wheel(0, 2200)
+        _pause()
+    return items[:limit]
 
 
-__all__ = ["ScrapedTournament", "TenUpScraper"]
-
+__all__ = [
+    "TENUP_URL",
+    "accept_cookies",
+    "click_retry",
+    "extract_cards",
+    "search_and_sort",
+    "select_discipline_padel",
+    "select_ligue_paca_alpes_maritimes",
+    "warn_client_side_date_filter",
+]

--- a/services/scrape.py
+++ b/services/scrape.py
@@ -1,47 +1,36 @@
-"""High level orchestration for scraping TenUp tournaments."""
+"""High-level orchestration to scrape TenUp tournaments with Playwright."""
 from __future__ import annotations
 
 import argparse
 import json
 import logging
-from dataclasses import dataclass
+from datetime import date, datetime, timezone
 from pathlib import Path
-from time import perf_counter
 from typing import Iterable, List, Optional, Sequence
 
-import pendulum
 from flask import Flask
+from playwright.sync_api import sync_playwright
 
 from extensions import db
-from scrapers.tenup import ScrapedTournament, TenUpScraper
+from scrapers.tenup import (
+    TENUP_URL,
+    accept_cookies,
+    extract_cards,
+    search_and_sort,
+    select_discipline_padel,
+    select_ligue_paca_alpes_maritimes,
+    warn_client_side_date_filter,
+)
 from services.tournament_store import TournamentStore
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = BASE_DIR / "data"
+LOG_PATH = DATA_DIR / "logs" / "tenup.log"
 DATABASE_PATH = DATA_DIR / "app.db"
 JSON_PATH = DATA_DIR / "tournaments.json"
-CONFIG_PATH = BASE_DIR / "config.json"
-LOG_PATH = DATA_DIR / "logs" / "tenup.log"
 
-
-DEFAULT_LEVELS = ["P100", "P250", "P500", "P1000", "P1500", "P2000"]
-DEFAULT_CATEGORIES = ["H", "F", "MIXTE"]
-
-
-@dataclass(slots=True)
-class ScrapeParameters:
-    region: str
-    date_from: str
-    date_to: str
-    categories: List[str]
-    levels: List[str]
-    limit: int
-
-
-def _load_config(path: Path = CONFIG_PATH) -> dict:
-    if not path.exists():
-        return {}
-    return json.loads(path.read_text(encoding="utf-8"))
+DEFAULT_REGION = "PROVENCE ALPES COTE D’AZUR"
+DEFAULT_COMMITTEE = "ALPES MARITIMES"
 
 
 def _ensure_storage() -> None:
@@ -50,242 +39,217 @@ def _ensure_storage() -> None:
     DATABASE_PATH.touch(exist_ok=True)
 
 
+def _configure_logging() -> logging.Logger:
+    logger = logging.getLogger()
+    if logger.handlers:
+        return logging.getLogger("services.scrape")
+
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    file_handler = logging.FileHandler(LOG_PATH, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    return logging.getLogger("services.scrape")
+
+
 def _create_app(sqlite_path: Path) -> Flask:
-    app = Flask("tenpadel-scraper")
+    app = Flask("tenup-scraper")
     app.config.update(
         SQLALCHEMY_DATABASE_URI=f"sqlite:///{sqlite_path}",
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
-        TENUP_CONFIG=_load_config().get("tenup", {}),
     )
     db.init_app(app)
     return app
 
 
-def _compute_date_range(
-    date_from: Optional[str], date_to: Optional[str], default_window_days: int = 60
-) -> tuple[str, str]:
-    tz = "Europe/Paris"
-    start = pendulum.parse(date_from, strict=False) if date_from else pendulum.now(tz)
-    end = pendulum.parse(date_to, strict=False) if date_to else start.add(days=default_window_days)
-    if end < start:
-        start, end = end, start
-    return start.to_date_string(), end.to_date_string()
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    return datetime.strptime(value, "%Y-%m-%d").date()
 
 
-def _parse_cli_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Scrape TenUp tournaments (Playwright only)")
-    parser.add_argument("--region", help="Région administrative à filtrer")
-    parser.add_argument("--from", dest="date_from", help="Date de début (YYYY-MM-DD)")
-    parser.add_argument("--to", dest="date_to", help="Date de fin (YYYY-MM-DD)")
-    parser.add_argument(
-        "--category",
-        action="append",
-        help="Catégorie à inclure (H, F, MIXTE). Peut être utilisée plusieurs fois.",
-    )
-    parser.add_argument(
-        "--level",
-        action="append",
-        help="Niveau à inclure (P100, P250, ...). Peut être utilisée plusieurs fois.",
-    )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        default=200,
-        help="Nombre maximum de tournois à collecter.",
-    )
-    return parser.parse_args(argv)
-
-
-def _resolve_parameters(config: dict, args: argparse.Namespace) -> ScrapeParameters:
-    tenup_cfg = config.get("tenup", {})
-    region = args.region or tenup_cfg.get("default_region", "")
-
-    tz = "Europe/Paris"
-    now = pendulum.now(tz)
-    start = pendulum.parse(args.date_from, strict=False) if args.date_from else now
-    end = pendulum.parse(args.date_to, strict=False) if args.date_to else now.add(days=60)
-    if end < start:
-        start, end = end, start
-
-    categories = [token.strip().upper() for token in (args.category or []) if token]
-    if not categories:
-        categories = [
-            str(token).upper()
-            for token in tenup_cfg.get("default_categories", DEFAULT_CATEGORIES)
-        ]
-
-    levels = [token.strip().upper() for token in (args.level or []) if token]
-    if not levels:
-        levels = [
-            str(token).upper() for token in tenup_cfg.get("default_levels", DEFAULT_LEVELS)
-        ]
-
-    limit = max(1, min(int(args.limit or tenup_cfg.get("max_results", 200)), 1000))
-
-    return ScrapeParameters(
-        region=region,
-        date_from=start.to_date_string(),
-        date_to=end.to_date_string(),
-        categories=categories,
-        levels=levels,
-        limit=limit,
-    )
-
-
-def _configure_logging() -> None:
-    root_logger = logging.getLogger()
-    if any(
-        isinstance(handler, logging.FileHandler)
-        and getattr(handler, "baseFilename", "") == str(LOG_PATH)
-        for handler in root_logger.handlers
-    ):
-        return
-
-    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    file_handler = logging.FileHandler(LOG_PATH, encoding="utf-8")
-    stream_handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-    file_handler.setFormatter(formatter)
-    stream_handler.setFormatter(formatter)
-
-    root_logger.setLevel(logging.INFO)
-    root_logger.addHandler(stream_handler)
-    root_logger.addHandler(file_handler)
-
-
-def scrape_tenup(
-    config: dict,
+def _filter_and_normalise(
+    items: Iterable[dict],
     *,
-    categories: Optional[Iterable[str]] = None,
-    date_from: Optional[str] = None,
-    date_to: Optional[str] = None,
-    region: Optional[str] = None,
-    city: Optional[str] = None,
-    radius_km: Optional[int] = None,
-    level: Optional[Iterable[str]] = None,
-    limit: Optional[int] = None,
-) -> tuple[List[dict], dict]:
-    """Scrape TenUp tournaments without persisting the results."""
-
-    _ensure_storage()
-    _configure_logging()
-
-    tenup_cfg = (config or {}).get("tenup", {})
-
-    resolved_categories = [token.strip().upper() for token in (categories or []) if token]
-    if not resolved_categories:
-        resolved_categories = [
-            str(token).upper()
-            for token in tenup_cfg.get("default_categories", DEFAULT_CATEGORIES)
-        ]
-
-    resolved_levels = [token.strip().upper() for token in (level or []) if token]
-    if not resolved_levels:
-        resolved_levels = [
-            str(token).upper() for token in tenup_cfg.get("default_levels", DEFAULT_LEVELS)
-        ]
-
-    start_date, end_date = _compute_date_range(date_from, date_to)
-
-    limit_value = int(limit or tenup_cfg.get("max_results", 200))
-    limit_value = max(1, min(limit_value, 1000))
-
-    region_value = region or tenup_cfg.get("default_region")
-
-    scraper = TenUpScraper(
-        base_url=tenup_cfg.get("base_url", "https://tenup.fft.fr/recherche/tournois"),
-        headless=bool(tenup_cfg.get("headless", True)),
-        request_timeout_ms=int(tenup_cfg.get("request_timeout_ms", 30000)),
-        respect_rate_limit=bool(tenup_cfg.get("respect_rate_limit", True)),
-        log_path=LOG_PATH,
-        random_delay_range=(1.2, 2.0),
-        max_retries=3,
-    )
-
-    started = perf_counter()
-    tournaments: List[ScrapedTournament] = scraper.scrape(
-        region=region_value,
-        date_from=start_date,
-        date_to=end_date,
-        categories=resolved_categories,
-        levels=resolved_levels,
-        limit=limit_value,
-    )
-    duration = perf_counter() - started
-
-    payload = [item.asdict() for item in tournaments]
-    meta = {
-        "duration_s": round(duration, 3),
-        "categories": resolved_categories,
-        "date_from": start_date,
-        "date_to": end_date,
-        "level": resolved_levels,
-        "geo": {"region": region_value, "city": city, "radius_km": radius_km},
-        "fetched": len(payload),
-    }
-    return payload, meta
-
-
-def scrape_all(
     region: str,
-    date_from: str,
-    date_to: str,
-    categories: Iterable[str],
-    levels: Iterable[str],
-    limit: int = 200,
+    date_from: Optional[str],
+    date_to: Optional[str],
+    limit: int,
+    logger: logging.Logger,
 ) -> List[dict]:
-    """Scrape TenUp tournaments and persist results to JSON and SQLite."""
+    start_bound = _parse_date(date_from)
+    end_bound = _parse_date(date_to)
 
-    _ensure_storage()
-    _configure_logging()
+    unique: dict[str, dict] = {}
+    for raw in items:
+        tid = raw.get("tournament_id")
+        start_value = raw.get("start_date")
+        end_value = raw.get("end_date") or start_value
+        if not tid or not start_value:
+            continue
 
-    config = _load_config()
-    payload, _meta = scrape_tenup(
-        config,
-        categories=list(categories),
-        date_from=date_from,
-        date_to=date_to,
-        region=region,
-        level=list(levels),
-        limit=limit,
-    )
+        start_date = _parse_date(start_value)
+        end_date = _parse_date(end_value) if end_value else None
+        if start_bound and (not start_date or start_date < start_bound):
+            continue
+        if end_bound:
+            if not end_date:
+                continue
+            if end_date > end_bound:
+                continue
 
+        start_iso = start_date.isoformat()
+        end_iso = end_date.isoformat() if end_date else start_iso
+
+        normalised = {
+            "tournament_id": tid,
+            "name": raw.get("name", ""),
+            "level": raw.get("level"),
+            "category": raw.get("category") or "PADEL",
+            "club_name": raw.get("club_name"),
+            "club_code": None,
+            "organizer": None,
+            "city": raw.get("city"),
+            "region": region,
+            "address": None,
+            "start_date": start_iso,
+            "end_date": end_iso,
+            "registration_deadline": None,
+            "surface": None,
+            "indoor_outdoor": None,
+            "draw_size": None,
+            "price": None,
+            "status": None,
+            "detail_url": raw.get("detail_url") or TENUP_URL,
+            "registration_url": raw.get("registration_url"),
+        }
+        unique[tid] = normalised
+
+    filtered = list(unique.values())
+    filtered.sort(key=lambda item: (item["start_date"], item["tournament_id"]))
+    if limit:
+        filtered = filtered[:limit]
+
+    logger.info("Fetched %d tournaments.", len(filtered))
+    return filtered
+
+
+def _stamp_records(records: Iterable[dict]) -> List[dict]:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    stamped: List[dict] = []
+    for record in records:
+        payload = dict(record)
+        payload.setdefault("last_scraped_at", now_iso)
+        payload.setdefault("registration_url", None)
+        stamped.append(payload)
+    return stamped
+
+
+def _persist(records: Sequence[dict]) -> None:
     app = _create_app(DATABASE_PATH)
     with app.app_context():
         db.create_all()
         store = TournamentStore(db, JSON_PATH)
-        store.upsert_many(payload)
+        store.upsert_many(records)
 
-    return payload
+
+def scrape_all(
+    region: str,
+    committee: str,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    limit: int = 500,
+) -> List[dict]:
+    """Scrape TenUp tournaments, filter client-side and persist results."""
+
+    _ensure_storage()
+    logger = _configure_logging()
+
+    logger.info(
+        "Starting TenUp scrape",
+        extra={"region": region, "committee": committee, "limit": limit},
+    )
+    warn_client_side_date_filter(logger)
+
+    raw_items: List[dict] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            locale="fr-FR",
+            timezone_id="Europe/Paris",
+            viewport={"width": 1440, "height": 900},
+        )
+        page = context.new_page()
+        try:
+            page.goto(TENUP_URL, wait_until="domcontentloaded")
+            page.wait_for_load_state("networkidle")
+            accept_cookies(page)
+            select_ligue_paca_alpes_maritimes(
+                page, region=region, committee=committee, logger=logger
+            )
+            select_discipline_padel(page, logger=logger)
+            search_and_sort(page, logger=logger)
+            raw_items = extract_cards(page, limit=limit)
+        finally:
+            context.close()
+            browser.close()
+
+    processed = _filter_and_normalise(
+        raw_items,
+        region=region,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        logger=logger,
+    )
+    stamped = _stamp_records(processed)
+
+    JSON_PATH.write_text(
+        json.dumps(stamped, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    _persist(stamped)
+    return stamped
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Scrape TenUp tournaments (UI only)")
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help="Nom de la ligue (par défaut: PROVENCE ALPES COTE D’AZUR)",
+    )
+    parser.add_argument(
+        "--committee",
+        default=DEFAULT_COMMITTEE,
+        help="Nom du comité (par défaut: ALPES MARITIMES)",
+    )
+    parser.add_argument("--date-from", dest="date_from", help="Date de début YYYY-MM-DD")
+    parser.add_argument("--date-to", dest="date_to", help="Date de fin YYYY-MM-DD")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Nombre maximum de tournois à retourner",
+    )
+    return parser
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    args = _parse_cli_arguments(argv)
-    config = _load_config()
-    params = _resolve_parameters(config, args)
-
-    _ensure_storage()
-    _configure_logging()
-
-    logging.getLogger("services.scrape").info(
-        "Scraping TenUp",
-        extra={
-            "region": params.region,
-            "date_from": params.date_from,
-            "date_to": params.date_to,
-            "categories": params.categories,
-            "levels": params.levels,
-            "limit": params.limit,
-        },
-    )
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
 
     results = scrape_all(
-        region=params.region,
-        date_from=params.date_from,
-        date_to=params.date_to,
-        categories=params.categories,
-        levels=params.levels,
-        limit=params.limit,
+        region=args.region,
+        committee=args.committee,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        limit=int(args.limit or 500),
     )
 
     print(f"🎯 TenUp scraping terminé – {len(results)} tournois")
@@ -294,6 +258,5 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI usage
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
- replace the TenUp scraper helpers with resilient Playwright interactions that match the updated Ligue, discipline and result pages
- add a new scrape_all entrypoint that drives Playwright, filters dates client-side, persists tournaments to SQLite/JSON, and exposes an argparse CLI

## Testing
- python -m compileall scrapers/tenup.py services/scrape.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f3e5ad5c8321b646013820228e90