### PR TITLE
Improve TenUp tournament scraping resilience

### DIFF
--- a/services/scrape.py
+++ b/services/scrape.py
@@ -18,107 +18,157 @@ from scrapers.tenup import (
     navigate_to_results,
 )
 
-FR_MONTHS = {
-    "janv": 1,
-    "jan.": 1,
-    "févr": 2,
-    "fév.": 2,
-    "mars": 3,
-    "avr": 4,
-    "avr.": 4,
-    "mai": 5,
-    "juin": 6,
-    "juil": 7,
-    "juil.": 7,
-    "août": 8,
-    "sept": 9,
-    "sep.": 9,
-    "oct": 10,
-    "oct.": 10,
-    "nov": 11,
-    "déc": 12,
-    "déc.": 12,
-}
 
 
-def _fr_to_iso(value: str) -> str | None:
-    import re
+def _extract_cards(page, limit=500, debug=False):
+    """
+    Extraction tolérante des tournois sur TenUp.
+    - Essaie plusieurs sélecteurs de 'cartes'
+    - Log le nombre d’éléments par sélecteur (debug)
+    - Fallback: dump HTML/PNG si 0 carte
+    - Parse: titre, dates FR -> ISO, niveau (Pxxx), catégorie (DM/DX/SM/SD), club/ville
+    """
+    import re, time, os
 
-    match = re.search(r"(\d{1,2})\s+([a-zéû\.]+)\s+(\d{4})", value.lower())
-    if not match:
-        return None
-    day = int(match.group(1))
-    month = FR_MONTHS.get(match.group(2))
-    year = int(match.group(3))
-    if not month:
-        return None
-    return f"{year:04d}-{month:02d}-{day:02d}"
+    items = []
 
+    # 1) Attendre l'affichage des résultats (si le libellé existe)
+    try:
+        page.wait_for_selector("text=RÉSULTATS", timeout=12000)
+    except Exception:
+        pass  # pas bloquant
 
-def _extract_cards(page, limit: int = 500) -> List[Dict]:
-    import re
+    # 2) Forcer le chargement par défilement (au cas où)
+    for _ in range(8):
+        page.mouse.wheel(0, 2200)
+        time.sleep(0.6)
 
-    items: List[Dict] = []
-    seen = -1
-    while len(items) < limit and len(items) != seen:
-        seen = len(items)
-        cards = page.locator("article, div[data-testid='event-card']").all()
-        for card in cards:
-            if len(items) >= limit:
-                break
-            try:
-                text = card.inner_text()
-            except Exception:
-                continue
-            try:
-                heading = card.get_by_role("heading")
-                if heading.count():
-                    name = heading.first.inner_text().strip()
-                else:
-                    name = text.splitlines()[0].strip()
-            except Exception:
-                name = text.splitlines()[0].strip() if text else ""
-            if not name:
-                continue
-            raw_dates = re.findall(r"\d{1,2}\s+[a-zéû\.]+\.?\s+\d{4}", text.lower())
-            start_iso = _fr_to_iso(raw_dates[0]) if raw_dates else None
-            end_iso = _fr_to_iso(raw_dates[1]) if len(raw_dates) > 1 else start_iso
-            level_match = re.search(r"\bP(100|250|500|1000|1500|2000)\b", text)
-            level = level_match.group(0) if level_match else None
-            cat_match = re.search(r"\bDM(?:\s*/\s*DX)?|\bSM\s*/\s*SD|\bDX\b", text, re.I)
-            category = cat_match.group(0).upper().replace(" ", "") if cat_match else None
-            location_line = next((line for line in text.splitlines() if "," in line), "")
+    # 3) Essayer plusieurs sélecteurs possibles
+    candidate_selectors = [
+        "article",
+        "div[data-testid='event-card']",
+        "li:has(div:has-text('DM'))",
+        "div.card, div.card-event",
+        "div:has(> div:has-text('DM'))",
+    ]
+
+    chosen_cards = []
+    best_count = -1
+    for sel in candidate_selectors:
+        try:
+            loc = page.locator(sel)
+            cnt = loc.count()
+            if debug:
+                print(f"[DEBUG] Sélecteur '{sel}' -> {cnt} éléments")
+            # Heuristique: prendre le sélecteur qui donne le plus d'éléments
+            if cnt > best_count:
+                best_count = cnt
+                chosen_cards = loc.all()
+        except Exception:
+            continue
+
+    if debug:
+        print(f"[DEBUG] Total cartes retenues: {len(chosen_cards)}")
+
+    # 4) Si rien trouvé, dump la page pour inspection
+    if not chosen_cards:
+        try:
+            os.makedirs("data", exist_ok=True)
+            with open("data/last_page.html", "w", encoding="utf-8") as f:
+                f.write(page.content())
+            page.screenshot(path="data/last_page.png", full_page=True)
+            print("[DEBUG] 0 carte — dump écrit: data/last_page.html / data/last_page.png")
+        except Exception:
+            pass
+        return []
+
+    # 5) Helpers parsing
+    FR_MONTHS = {
+        "janv": 1,
+        "jan.": 1,
+        "févr": 2,
+        "fév.": 2,
+        "mars": 3,
+        "avr": 4,
+        "avr.": 4,
+        "mai": 5,
+        "juin": 6,
+        "juil": 7,
+        "juil.": 7,
+        "août": 8,
+        "sept": 9,
+        "sep.": 9,
+        "oct": 10,
+        "oct.": 10,
+        "nov": 11,
+        "déc": 12,
+        "déc.": 12,
+    }
+
+    def fr_to_iso(s: str) -> str | None:
+        m = re.search(r"(\d{1,2})\s+([a-zéû\.]+)\s+(\d{4})", s.lower())
+        if not m:
+            return None
+        d, mo, y = int(m.group(1)), FR_MONTHS.get(m.group(2)), int(m.group(3))
+        return f"{y:04d}-{mo:02d}-{d:02d}" if mo else None
+
+    # 6) Parcours et parsing heuristique
+    for c in chosen_cards[:limit]:
+        try:
+            txt = c.inner_text()
+
+            # Titre
+            if c.get_by_role("heading").count():
+                name = c.get_by_role("heading").first.inner_text().strip()
+            else:
+                lines = [l.strip() for l in txt.splitlines() if l.strip()]
+                name = lines[0] if lines else "Tournoi"
+
+            # Dates (ex: "5 oct. 2025")
+            raw_dates = re.findall(r"\d{1,2}\s+[a-zéû\.]+\.?\s+\d{4}", txt.lower())
+            start_date = fr_to_iso(raw_dates[0]) if raw_dates else None
+            end_date = fr_to_iso(raw_dates[1]) if len(raw_dates) > 1 else start_date
+
+            # Niveau / Catégorie
+            m_level = re.search(r"\bP(100|250|500|1000|1500|2000)\b", txt)
+            level = m_level.group(0) if m_level else None
+            m_cat = re.search(r"\bDM(?:\s*/\s*DX)?|\bSM\s*/\s*SD|\bDX\b", txt, re.I)
+            category = m_cat.group(0).upper().replace(" ", "") if m_cat else None
+
+            # Club / Ville : ligne contenant une virgule
             club = city = None
-            if location_line:
-                parts = [segment.strip() for segment in location_line.split(",")]
-                if len(parts) > 1:
-                    club = ", ".join(parts[:-1])
-                    city = parts[-1]
-                else:
-                    club = parts[0]
-                    city = None
-            tournament_id = re.sub(
-                r"\W+", "-", f"{name}-{start_iso}-{end_iso}"
-            ).strip("-").lower()
-            if not tournament_id:
-                continue
+            loc_line = next((l for l in txt.splitlines() if "," in l), "")
+            if loc_line:
+                parts = [p.strip() for p in loc_line.split(",")]
+                club = ", ".join(parts[:-1]) if len(parts) > 1 else parts[0]
+                city = parts[-1] if len(parts) > 1 else None
+
+            # ID stable
+            import re as _re
+
+            tid = _re.sub(r"\W+", "-", f"{name}-{start_date}-{end_date}").strip("-").lower()
+
             items.append(
                 {
-                    "tournament_id": tournament_id,
+                    "tournament_id": tid,
                     "name": name,
                     "level": level,
                     "category": category,
                     "club_name": club,
                     "city": city,
-                    "start_date": start_iso,
-                    "end_date": end_iso,
+                    "start_date": start_date,
+                    "end_date": end_date,
                     "detail_url": None,
                     "registration_url": None,
                 }
             )
-        page.mouse.wheel(0, 2000)
-        time.sleep(0.8)
-    return items[:limit]
+        except Exception:
+            continue
+
+    if debug:
+        print(f"[DEBUG] Items extraits: {len(items)}")
+    return items
+
 
 
 def _save_results(items: List[Dict]) -> None:
@@ -190,7 +240,13 @@ def scrape_all(
         select_discipline_padel(page)
         apply_sort_by_start_date(page)
         navigate_to_results(page)
-        items = _extract_cards(page, limit=limit)
+
+        # forcer à charger plus d’éléments (si lazy-load)
+        for _ in range(8):
+            page.mouse.wheel(0, 2200)
+            time.sleep(0.6)
+
+        items = _extract_cards(page, limit=limit, debug=True)   # 1er run en debug
         browser.close()
 
     if date_from:


### PR DESCRIPTION
## Summary
- replace the TenUp card extractor with a tolerant, debug-friendly parser that supports multiple selectors and fallback dumping
- force additional scrolling before extraction and invoke the scraper in debug mode for better diagnostics

## Testing
- python -m services.scrape *(fails: ModuleNotFoundError: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68e2fba525dc8321817d376d4608964b