### PR TITLE
Refine TenUp scraper to load all tournaments

### DIFF
--- a/scrapers/tenup.py
+++ b/scrapers/tenup.py
@@ -11,7 +11,7 @@ from playwright.sync_api import Page
 def _pause() -> None:
     """Sleep a short random delay to avoid hammering the UI."""
 
-    time.sleep(random.uniform(1.1, 2.0))
+    time.sleep(random.uniform(1.0, 1.8))
 
 
 def _click(locator, attempts: int = 3, timeout: float = 8000) -> None:
@@ -39,34 +39,12 @@ def accept_cookies(page: Page) -> None:
         pass
 
 
-def select_ligue_paca_alpes_maritimes(page: Page) -> None:
-    """Select the PACA league and Alpes Maritimes committee."""
-
-    _click(page.get_by_text("Ligue", exact=True))
-    _click(page.get_by_role("button", name=re.compile(r"Dans quelle ligue voulez-vous", re.I)))
-    _click(page.get_by_text("PROVENCE ALPES COTE D'AZUR", exact=True))
-    _click(page.get_by_role("link", name="SUIVANT"))
-    _click(page.get_by_role("button", name="ALPES MARITIMES"))
-    _click(page.get_by_role("link", name="VALIDER"))
-
-
 def select_discipline_padel(page: Page) -> None:
     """Switch the search discipline to padel."""
 
     _click(page.get_by_role("heading", name="Tennis"))
     _click(page.get_by_text("Padel", exact=True))
-    _click(page.get_by_text("Padel", exact=True))
     _click(page.get_by_role("button", name=re.compile(r"Appliquer", re.I)))
-
-
-def apply_sort_by_start_date(page: Page) -> None:
-    """Try to sort results by start date; fallback is handled client-side."""
-
-    try:
-        page.get_by_role("combobox").select_option("dateDebut asc")
-        _pause()
-    except Exception:
-        print("WARNING: Tri UI indisponible; tri côté code.")
 
 
 def navigate_to_results(page: Page) -> None:
@@ -77,8 +55,6 @@ def navigate_to_results(page: Page) -> None:
 
 __all__ = [
     "accept_cookies",
-    "select_ligue_paca_alpes_maritimes",
     "select_discipline_padel",
-    "apply_sort_by_start_date",
     "navigate_to_results",
 ]


### PR DESCRIPTION
## Summary
- simplify the TenUp Playwright helper to only perform the minimum cookie and discipline interactions
- overhaul the scrape orchestration to scroll-load every card, add resilient extraction, and persist results with nullable URLs
- add debug logging/exports, client-side filtering, and compatibility alias updates for the scraper entry point

## Testing
- not run (network access to tenup.fft.fr required)


------
https://chatgpt.com/codex/tasks/task_e_68e2feab3e4c8321aef648aae5409f1b