### PR TITLE
Automate manual scrape workflow with DB import scripts

### DIFF
--- a/Reset-DB.command
+++ b/Reset-DB.command
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+rm -f data/app.db
+echo "🧹 Base supprimée (data/app.db). Elle sera recréée au prochain import."

--- a/Scrape-Manual-Full.command
+++ b/Scrape-Manual-Full.command
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+[ -d ".venv" ] && source .venv/bin/activate
+echo "🟢 Scraping semi-auto + import DB"
+python -m services.manual_scrape
+echo "✅ Terminé — les tournois sont à jour dans l’app"

--- a/Start-And-Open.command
+++ b/Start-And-Open.command
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+[ -d ".venv" ] && source .venv/bin/activate
+./Start-TenPadel.command &
+sleep 2
+./Open-App.command

--- a/services/db_import.py
+++ b/services/db_import.py
@@ -1,0 +1,59 @@
+import sqlite3
+from pathlib import Path
+from typing import List, Dict
+
+BASE = Path(__file__).resolve().parent.parent
+DB    = BASE / "data" / "app.db"
+
+COLUMNS = [
+    "name","level","category","club_name","city",
+    "start_date","end_date","detail_url","registration_url"
+]
+
+def ensure_schema():
+    DB.parent.mkdir(exist_ok=True)
+    con = sqlite3.connect(str(DB))
+    cur = con.cursor()
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS tournaments(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            level TEXT,
+            category TEXT,
+            club_name TEXT,
+            city TEXT,
+            start_date TEXT,
+            end_date TEXT,
+            detail_url TEXT NOT NULL UNIQUE,
+            registration_url TEXT
+        );
+    """)
+    cur.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_detail_url ON tournaments(detail_url);")
+    con.commit()
+    con.close()
+
+def _row(it: Dict):
+    # alias + garde-fous
+    if not it.get("detail_url") and it.get("url"):
+        it["detail_url"] = it["url"]
+    if not it.get("detail_url"):
+        return None
+    it["name"] = (it.get("name") or it.get("title") or "Tournoi").strip()
+    return tuple((it.get(k) if k != "name" else it["name"]) for k in COLUMNS)
+
+def import_items(items: List[Dict]) -> int:
+    """INSERT OR IGNORE par detail_url (idempotent). Renvoie le nb de nouvelles lignes."""
+    ensure_schema()
+    con = sqlite3.connect(str(DB))
+    cur = con.cursor()
+    q = f"INSERT OR IGNORE INTO tournaments({','.join(COLUMNS)}) VALUES ({','.join(['?']*len(COLUMNS))})"
+    ok = 0
+    for it in items:
+        tup = _row(it)
+        if not tup:
+            continue
+        cur.execute(q, tup)
+        ok += cur.rowcount
+    con.commit()
+    con.close()
+    return ok

--- a/services/manual_scrape.py
+++ b/services/manual_scrape.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from playwright.sync_api import sync_playwright
 
 from scrapers.tenup import extract_current_page_items, try_click_next
+from services.db_import import import_items
 
 BASE = Path(__file__).resolve().parent.parent
 DATA = BASE / "data"
@@ -92,6 +93,10 @@ def main() -> None:
         }
         OUT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         SNAPSHOT.write_text(page.content(), encoding="utf-8")
+
+        inserted = import_items(all_items)
+        print(f"🗃  Import DB: +{inserted} nouvelles lignes (idempotent)")
+        print("✅ Fin du workflow: scrape → JSON/snapshot → DB (auto)")
 
         context.close()
         browser.close()


### PR DESCRIPTION
## Summary
- add a reusable database import module for tournaments data
- hook the manual scraper workflow to import scraped tournaments automatically
- add helper .command scripts to start the app, run the manual scrape, and reset the database

## Testing
- python -m compileall services/db_import.py services/manual_scrape.py

------
https://chatgpt.com/codex/tasks/task_e_68e3aec877788321a85d4baccd913c89