### PR TITLE
Expose tournaments sorted by date and highlight calendar days

### DIFF
--- a/api/tournaments.py
+++ b/api/tournaments.py
@@ -1,27 +1,18 @@
 """REST API endpoints exposing TenUp tournaments."""
 from __future__ import annotations
 
-from typing import List, Sequence
-
-import pendulum
 from flask import Blueprint, jsonify, request
-from sqlalchemy import asc, desc, or_
+from sqlalchemy import asc, desc
 
 from services.tournament_store_models import TournamentRecord
 
 bp = Blueprint("tournaments_api", __name__, url_prefix="/api")
 
 
-def _parse_levels(raw_level: str | Sequence[str] | None) -> List[str]:
-    if raw_level is None:
-        return []
-    if isinstance(raw_level, (list, tuple)):
-        return [str(item).upper() for item in raw_level if item]
-    return [token.strip().upper() for token in str(raw_level).split(",") if token.strip()]
-
-
 @bp.route("/tournaments", methods=["GET"])
 def list_tournaments():
+    """Return all tournaments ordered by their start date."""
+
     limit_raw = request.args.get("limit")
     try:
         limit = int(limit_raw) if limit_raw is not None else 1000
@@ -29,80 +20,7 @@ def list_tournaments():
         limit = 1000
     limit = max(1, min(limit, 5000))
 
-    query = TournamentRecord.query
-    category = request.args.get("category")
-    if category:
-        query = query.filter(TournamentRecord.category == category.upper())
-
-    level_tokens = _parse_levels(request.args.getlist("level"))
-    if level_tokens:
-        query = query.filter(TournamentRecord.level.in_(level_tokens))
-
-    city = request.args.get("city")
-    if city:
-        city = city.strip()
-        if city:
-            query = query.filter(
-                or_(
-                    TournamentRecord.city.ilike(f"%{city}%"),
-                    TournamentRecord.city.is_(None),
-                    TournamentRecord.city == "",
-                )
-            )
-
-    region = request.args.get("region")
-    if region:
-        region = region.strip()
-        if region:
-            query = query.filter(
-                or_(
-                    TournamentRecord.region == region,
-                    TournamentRecord.region.is_(None),
-                    TournamentRecord.region == "",
-                )
-            )
-
-    date_from = request.args.get("from")
-    date_to = request.args.get("to")
-    start = None
-    end = None
-    if date_from:
-        try:
-            start = pendulum.parse(date_from, strict=False).to_date_string()
-        except Exception:  # pragma: no cover - invalid user input
-            start = None
-    if date_to:
-        try:
-            end = pendulum.parse(date_to, strict=False).to_date_string()
-        except Exception:  # pragma: no cover - invalid user input
-            end = None
-
-    if start and end:
-        query = query.filter(
-            or_(
-                TournamentRecord.start_date.between(start, end),
-                TournamentRecord.start_date.is_(None),
-                TournamentRecord.start_date == "",
-            )
-        )
-    elif start:
-        query = query.filter(
-            or_(
-                TournamentRecord.start_date >= start,
-                TournamentRecord.start_date.is_(None),
-                TournamentRecord.start_date == "",
-            )
-        )
-    elif end:
-        query = query.filter(
-            or_(
-                TournamentRecord.start_date <= end,
-                TournamentRecord.start_date.is_(None),
-                TournamentRecord.start_date == "",
-            )
-        )
-
-    query = query.order_by(
+    query = TournamentRecord.query.order_by(
         TournamentRecord.start_date.is_(None),
         asc(TournamentRecord.start_date),
         desc(TournamentRecord.id),

--- a/services/tournament_store_models.py
+++ b/services/tournament_store_models.py
@@ -62,6 +62,7 @@ class TournamentRecord(db.Model):
             "region": self.region,
             "start_date": self.start_date,
             "end_date": self.end_date,
+            "date": self.start_date,
             "registration_deadline": self.registration_deadline,
             "surface": self.surface,
             "indoor_outdoor": self.indoor_outdoor,

--- a/static/style.css
+++ b/static/style.css
@@ -263,7 +263,7 @@ a.secondary:focus,
   background: #f2f4f8;
 }
 
-.calendar-table td.has-tournament {
+.calendar-table td.has-event {
   background: #fff7d6;
   cursor: pointer;
 }
@@ -274,15 +274,15 @@ a.secondary:focus,
   background: #ffe6a1;
 }
 
-.calendar-marker {
+.calendar-table td .dot {
   position: absolute;
-  bottom: 6px;
   left: 50%;
+  bottom: 6px;
   transform: translateX(-50%);
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--warning);
+  background: #f3c22b;
 }
 
 .calendar-legend {
@@ -314,6 +314,48 @@ a.secondary:focus,
   margin: 0 0 1rem;
   color: var(--muted);
   font-size: 0.9rem;
+}
+
+.day-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.tour-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: #fdfdfd;
+}
+
+.tour-item .t-title {
+  font-weight: 600;
+  flex: 1;
+}
+
+.tour-item .t-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.tour-item .t-cta {
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.tour-item .t-cta:hover,
+.tour-item .t-cta:focus {
+  background: #1b3be0;
 }
 
 .tournament-list {

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,6 +98,7 @@
           </div>
         </div>
         <p id="admin-status" class="admin-status muted" hidden></p>
+        <div id="day-list" class="day-list" aria-live="polite"></div>
         <div id="tournament-list" class="tournament-list" aria-live="polite"></div>
         <p id="empty-state" class="empty-state" hidden>Aucun tournoi ne correspond aux filtres sélectionnés.</p>
       </section>
@@ -209,6 +210,7 @@
       const STATUS_LABELS = { true: 'Inscriptions ouvertes', false: 'Inscriptions fermées' };
       const STATUS_CLASSES = { true: 'status-open', false: 'status-closed', unknown: 'status-unknown' };
 
+      let ALL = [];
       const BY_DATE = new Map();
 
       const state = {
@@ -222,6 +224,7 @@
       };
 
       const listContainer = document.getElementById('tournament-list');
+      const dayListContainer = document.getElementById('day-list');
       const countLabel = document.getElementById('tournament-count');
       const emptyState = document.getElementById('empty-state');
       const calendarBody = document.getElementById('calendar-body');
@@ -345,7 +348,7 @@
       function indexByDate(source = []) {
         BY_DATE.clear();
         for (const tournament of source) {
-          const dateStr = tournament.start_date;
+          const dateStr = tournament.start_date || tournament.date || '';
           if (!dateStr) {
             continue;
           }
@@ -397,28 +400,53 @@
         state.filters.levels = selectedLevels;
       }
 
-      function buildQueryParams() {
-        const params = new URLSearchParams();
-        if (state.filters.category) {
-          params.set('category', state.filters.category);
+      function applyFilters(source, filters) {
+        if (!filters) {
+          return [...source];
         }
-        if (state.filters.from) {
-          params.set('from', state.filters.from);
-        }
-        if (state.filters.to) {
-          params.set('to', state.filters.to);
-        }
-        if (state.filters.region) {
-          params.set('region', state.filters.region);
-        }
-        if (state.filters.city) {
-          params.set('city', state.filters.city);
-        }
-        if (state.filters.radius) {
-          params.set('radius_km', state.filters.radius);
-        }
-        Array.from(state.filters.levels).forEach(level => params.append('level', level));
-        return params;
+        const wantedCategory = filters.category ? filters.category.toUpperCase() : '';
+        const levels = filters.levels instanceof Set ? filters.levels : new Set();
+        const fromDate = filters.from || '';
+        const toDate = filters.to || '';
+        const regionFilter = filters.region ? filters.region.toUpperCase() : '';
+        const cityFilter = filters.city ? filters.city.toLowerCase() : '';
+
+        return source.filter(tournament => {
+          if (wantedCategory && tournament.category !== wantedCategory) {
+            return false;
+          }
+
+          if (levels.size) {
+            const level = (tournament.level || '').toUpperCase();
+            if (!level || !levels.has(level)) {
+              return false;
+            }
+          }
+
+          const startDate = tournament.start_date || tournament.date || '';
+          if (fromDate && startDate && startDate < fromDate) {
+            return false;
+          }
+          if (toDate && startDate && startDate > toDate) {
+            return false;
+          }
+
+          if (regionFilter) {
+            const region = (tournament.region || '').toUpperCase();
+            if (region && region !== regionFilter) {
+              return false;
+            }
+          }
+
+          if (cityFilter) {
+            const city = (tournament.city || '').toLowerCase();
+            if (city && !city.includes(cityFilter)) {
+              return false;
+            }
+          }
+
+          return true;
+        });
       }
 
       async function loadTournaments(options = {}) {
@@ -430,24 +458,28 @@
         }
         state.tournaments = [];
         render();
-        const params = forceAll ? new URLSearchParams() : buildQueryParams();
-        const queryString = params.toString();
-        const endpoint = queryString ? `/api/tournaments?${queryString}` : '/api/tournaments';
+
         try {
-          const response = await fetch(endpoint);
-          if (!response.ok) {
-            throw new Error(`API error ${response.status}`);
+          if (forceAll || ALL.length === 0) {
+            const response = await fetch('/api/tournaments');
+            if (!response.ok) {
+              throw new Error(`API error ${response.status}`);
+            }
+            const payload = await response.json();
+            const list = Array.isArray(payload) ? payload : payload.items || [];
+            const normalised = list.map(normaliseTournament);
+            ALL = normalised;
+            window.ALL = normalised;
           }
-          const payload = await response.json();
-          const list = Array.isArray(payload) ? payload : payload.items || [];
-          const normalised = list.map(normaliseTournament);
-          window.ALL = normalised;
-          state.allTournaments = normalised;
-          indexByDate(normalised);
+
+          const workingList = forceAll ? ALL : applyFilters(ALL, state.filters);
+          state.allTournaments = workingList;
+          indexByDate(workingList);
           ensureSelectedDate();
         } catch (error) {
           console.error(error);
           window.ALL = [];
+          ALL = [];
           state.allTournaments = [];
           BY_DATE.clear();
           state.error = "Impossible de charger les tournois TenUp.";
@@ -491,6 +523,7 @@
       function render() {
         renderCalendar();
         renderList();
+        renderDay(state.selectedDate);
       }
 
       function renderCalendar() {
@@ -513,19 +546,11 @@
             } else {
               cell.textContent = day;
               const isoDate = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-              const hasEvents = BY_DATE.has(isoDate);
-              if (hasEvents) {
-                const marker = document.createElement('span');
-                marker.className = 'calendar-marker';
-                marker.title = 'Tournoi disponible';
-                cell.appendChild(marker);
-                cell.classList.add('has-tournament');
-              }
               if (state.selectedDate === isoDate) {
                 cell.classList.add('selected');
               }
               cell.dataset.date = isoDate;
-              cell.addEventListener('click', () => handleCalendarDayClick(isoDate));
+              cell.addEventListener('click', () => onCalendarDayClick(isoDate));
             }
             row.appendChild(cell);
             day += 1;
@@ -535,9 +560,35 @@
             break;
           }
         }
+        renderCalendarMarkers();
       }
 
-      function handleCalendarDayClick(dateStr) {
+      function renderCalendarMarkers() {
+        const cells = calendarBody.querySelectorAll('td');
+        cells.forEach(cell => {
+          cell.classList.remove('has-event');
+          const existing = cell.querySelector('.dot');
+          if (existing) {
+            existing.remove();
+          }
+        });
+
+        for (const [date] of BY_DATE.entries()) {
+          const cell = calendarBody.querySelector(`[data-date="${date}"]`);
+          if (!cell || cell.classList.contains('empty')) {
+            continue;
+          }
+          if (!cell.querySelector('.dot')) {
+            const dot = document.createElement('span');
+            dot.className = 'dot';
+            dot.title = 'Tournoi disponible';
+            cell.appendChild(dot);
+          }
+          cell.classList.add('has-event');
+        }
+      }
+
+      function onCalendarDayClick(dateStr) {
         if (!dateStr) {
           return;
         }
@@ -561,6 +612,44 @@
           day: 'numeric',
         });
         return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+      }
+
+      function renderDay(dateStr) {
+        if (!dayListContainer) {
+          return;
+        }
+        if (state.loading) {
+          dayListContainer.innerHTML = '<p>Chargement…</p>';
+          return;
+        }
+        if (state.error) {
+          dayListContainer.innerHTML = `<p>${state.error}</p>`;
+          return;
+        }
+        if (!dateStr) {
+          dayListContainer.innerHTML = '<p>Sélectionnez un jour dans le calendrier.</p>';
+          return;
+        }
+        const list = BY_DATE.get(dateStr) || [];
+        if (!list.length) {
+          dayListContainer.innerHTML = '<p>Aucun tournoi ce jour.</p>';
+          return;
+        }
+        dayListContainer.innerHTML = list
+          .map(tournament => {
+            const name = tournament.name || tournament.title || 'Tournoi';
+            const categoryKey = tournament.category || '';
+            const category = CATEGORY_LABELS[categoryKey] || categoryKey;
+            const url = tournament.detail_url || tournament.details_url || tournament.registration_url || '#';
+            return `
+              <div class="tour-item">
+                <div class="t-title">${name}</div>
+                <div class="t-meta">${category}</div>
+                <a class="t-cta" href="${url}" target="_blank" rel="noopener">S’inscrire</a>
+              </div>
+            `;
+          })
+          .join('');
       }
 
       function renderList() {


### PR DESCRIPTION
## Summary
- add a `date` alias when serialising tournaments so the front-end can index entries by day
- simplify the tournaments API to always return every tournament ordered by start date
- update the home page to fetch the full list once, add calendar dots, and render a per-day summary list with styles

## Testing
- python -m compileall api services

------
https://chatgpt.com/codex/tasks/task_e_68e43cfaa74c832191a421c33f988758