### PR TITLE
Align database paths and automate imports

### DIFF
--- a/Import-From-JSON.command
+++ b/Import-From-JSON.command
@@ -1,51 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")"
-if [ -d ".venv" ]; then
-  source .venv/bin/activate
-fi
-python - <<'PY'
-import json
-import sys
-from pathlib import Path
-
-from services.db_import import import_items
-
-path = Path("data/tournaments.json")
-if not path.exists():
-    print("❌ Fichier data/tournaments.json introuvable.", file=sys.stderr)
-    sys.exit(1)
-
-content = path.read_text(encoding="utf-8").strip()
-size = path.stat().st_size
-print(f"📄 Lecture JSON: {path} ({size} octets)")
-if not content:
-    tournaments = []
-else:
-    try:
-        raw = json.loads(content)
-    except json.JSONDecodeError as exc:
-        print(f"❌ JSON invalide: {exc}", file=sys.stderr)
-        sys.exit(1)
-    if isinstance(raw, dict):
-        tournaments = raw.get("tournaments")
-        if tournaments is None and isinstance(raw.get("items"), list):
-            tournaments = raw["items"]
-        if tournaments is None:
-            tournaments = []
-    elif isinstance(raw, list):
-        tournaments = raw
-    else:
-        print("❌ Format JSON inattendu.", file=sys.stderr)
-        sys.exit(1)
-
-if not isinstance(tournaments, list):
-    print("❌ Le contenu JSON ne contient pas une liste de tournois.", file=sys.stderr)
-    sys.exit(1)
-
-inserted = import_items([dict(item) for item in tournaments])
-print(f"✅ Import terminé — {inserted} nouvelles lignes ajoutées.")
-print(f"ℹ️ Total éléments lus dans le JSON : {len(tournaments)}")
-if len(tournaments) == 0:
-    print(f"⚠️ JSON vide lu depuis {path} — taille {size} octets.")
-PY
+[ -d ".venv" ] && source .venv/bin/activate
+python -m services.import_from_json

--- a/services/import_from_json.py
+++ b/services/import_from_json.py
@@ -1,0 +1,18 @@
+"""Utility script to import tournaments from the stored JSON payload."""
+from __future__ import annotations
+
+import json
+
+from tenpadel.config_paths import DB_PATH, JSON_PATH
+from services.db_import import import_items
+
+
+def main() -> None:
+    data = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    items = data.get("tournaments", []) if isinstance(data, dict) else []
+    inserted = import_items(items)
+    print(f"✅ Importé: {inserted} lignes depuis {JSON_PATH} → {DB_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tenpadel/__init__.py
+++ b/tenpadel/__init__.py
@@ -1,0 +1,3 @@
+"""Shared project utilities for TenPadel."""
+
+__all__ = ["config_paths"]

--- a/tenpadel/config_paths.py
+++ b/tenpadel/config_paths.py
@@ -1,0 +1,12 @@
+"""Centralised filesystem paths for the TenPadel project."""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA = ROOT / "data"
+DB_PATH = DATA / "app.db"
+JSON_PATH = DATA / "tournaments.json"
+LOG_DIR = DATA / "logs"
+
+__all__ = ["ROOT", "DATA", "DB_PATH", "JSON_PATH", "LOG_DIR"]


### PR DESCRIPTION
## Summary
- centralize shared filesystem paths in `tenpadel/config_paths.py` and update the Flask app to log and use the canonical database location
- enhance the scraper/import pipeline to reuse the shared paths, log database writes, and automatically import at the end of a manual scrape
- add a reusable JSON import module and command-line helper for recovery scenarios

## Testing
- python -m compileall app.py services tenpadel

------
https://chatgpt.com/codex/tasks/task_e_68e443fd72548321aa52d8dcfd1e16f2