### PR TITLE
Implement verbose UPSERT import workflow

### DIFF
--- a/services/db_import.py
+++ b/services/db_import.py
@@ -1,81 +1,102 @@
-"""Utilities to import scraped tournaments into the SQLite database."""
-
-from __future__ import annotations
-
-import logging
-import sqlite3
-from typing import Dict, List
-
+import re, sqlite3, logging
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import List, Dict
 
+# chemins uniques
 from tenpadel.config_paths import DB_PATH, LOG_DIR
-
-COLUMNS = [
-    "name","level","category","club_name","city",
-    "start_date","end_date","detail_url","registration_url"
-]
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 log = logging.getLogger("db_import")
 if not log.handlers:
     fh = RotatingFileHandler(LOG_DIR / "db_import.log", maxBytes=1_000_000, backupCount=2, encoding="utf-8")
     fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-    log.addHandler(fh)
-    log.setLevel(logging.INFO)
+    log.addHandler(fh); log.setLevel(logging.INFO)
+
+COLUMNS = ["name","level","category","club_name","city","start_date","end_date","detail_url","registration_url"]
+ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 def ensure_schema():
     DB_PATH.parent.mkdir(exist_ok=True)
-    con = sqlite3.connect(str(DB_PATH))
-    cur = con.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS tournaments(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT,
-            level TEXT,
-            category TEXT,
-            club_name TEXT,
-            city TEXT,
-            start_date TEXT,           -- ISO YYYY-MM-DD
-            end_date TEXT,
-            detail_url TEXT NOT NULL UNIQUE,
-            registration_url TEXT
-        );
-        """
-    )
-    cur.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_detail_url ON tournaments(detail_url);"
-    )
-    cur.execute(
-        "CREATE INDEX IF NOT EXISTS idx_start_date ON tournaments(start_date);"
-    )
-    con.commit()
-    con.close()
+    con = sqlite3.connect(str(DB_PATH)); cur = con.cursor()
+    cur.execute("""
+      CREATE TABLE IF NOT EXISTS tournaments(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT, level TEXT, category TEXT, club_name TEXT, city TEXT,
+        start_date TEXT, end_date TEXT,
+        detail_url TEXT NOT NULL UNIQUE,
+        registration_url TEXT
+      );
+    """)
+    cur.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_detail_url ON tournaments(detail_url);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_start_date ON tournaments(start_date);")
+    con.commit(); con.close()
     log.info("Schema ensured at %s", DB_PATH)
 
-def _row(it: Dict):
-    # alias + garde-fous
-    if not it.get("detail_url") and it.get("url"):
-        it["detail_url"] = it["url"]
-    if not it.get("detail_url"):
-        return None
+def _normalize(it: Dict) -> Dict:
+    it = dict(it)  # shallow copy
+    # alias + trims
+    it["detail_url"] = (it.get("detail_url") or it.get("url") or "").strip()
     it["name"] = (it.get("name") or it.get("title") or "Tournoi").strip()
-    return tuple((it.get(k) if k != "name" else it["name"]) for k in COLUMNS)
+    for k in ["level","category","club_name","city","start_date","end_date","registration_url"]:
+        if k in it and isinstance(it[k], str):
+            it[k] = it[k].strip()
+    # dates : garder vide si non-ISO, on loguera
+    if it.get("start_date") and not ISO_DATE.match(it["start_date"]):
+        log.debug("non ISO start_date, keep-as-is: %r for %s", it["start_date"], it["detail_url"])
+    return it
+
+def _validate(it: Dict) -> str | None:
+    if not it.get("detail_url"):
+        return "missing_detail_url"
+    if not it["detail_url"].startswith("http"):
+        return "bad_detail_url"
+    return None  # ok
 
 def import_items(items: List[Dict]) -> int:
-    """INSERT OR IGNORE par detail_url (idempotent). Renvoie le nb de nouvelles lignes."""
     ensure_schema()
-    con = sqlite3.connect(str(DB_PATH))
-    cur = con.cursor()
-    q = f"INSERT OR IGNORE INTO tournaments({','.join(COLUMNS)}) VALUES ({','.join(['?']*len(COLUMNS))})"
-    ok = 0
+    total = len(items)
+    valid = []
+    reasons = {}
     for it in items:
-        tup = _row(it)
-        if not tup:
+        it = _normalize(it)
+        err = _validate(it)
+        if err:
+            reasons[err] = reasons.get(err, 0) + 1
             continue
-        cur.execute(q, tup)
-        ok += cur.rowcount
+        valid.append(tuple(it.get(k) for k in COLUMNS))
+
+    log.info("Incoming items=%s  valid=%s  skipped=%s %s",
+             total, len(valid), total-len(valid), reasons if reasons else "")
+
+    if not valid:
+        log.warning("No valid items to import (DB untouched).")
+        return 0
+
+    con = sqlite3.connect(str(DB_PATH)); cur = con.cursor()
+
+    # UPSERT: si detail_url déjà présent, on met à jour quelques champs utiles
+    q = """
+    INSERT INTO tournaments(name,level,category,club_name,city,start_date,end_date,detail_url,registration_url)
+    VALUES (?,?,?,?,?,?,?,?,?)
+    ON CONFLICT(detail_url) DO UPDATE SET
+      name=excluded.name,
+      category=COALESCE(excluded.category, tournaments.category),
+      club_name=COALESCE(excluded.club_name, tournaments.club_name),
+      city=COALESCE(excluded.city, tournaments.city),
+      start_date=COALESCE(excluded.start_date, tournaments.start_date),
+      end_date=COALESCE(excluded.end_date, tournaments.end_date),
+      registration_url=COALESCE(excluded.registration_url, tournaments.registration_url)
+    ;
+    """
+    cur.executemany(q, valid)
     con.commit()
+
+    # comptage après import
+    cur.execute("SELECT COUNT(*) FROM tournaments")
+    rows = cur.fetchone()[0]
     con.close()
-    log.info("Import finished: +%s new rows into %s", ok, DB_PATH)
-    return ok
+
+    # ATTENTION: sqlite3.rowcount après executemany n'est pas fiable → on recompte
+    log.info("Import finished: db_rows_now=%s (db=%s)", rows, DB_PATH)
+    return rows

--- a/services/import_from_json.py
+++ b/services/import_from_json.py
@@ -1,18 +1,13 @@
-"""Utility script to import tournaments from the stored JSON payload."""
-from __future__ import annotations
-
 import json
-
-from tenpadel.config_paths import DB_PATH, JSON_PATH
+from tenpadel.config_paths import JSON_PATH, DB_PATH
 from services.db_import import import_items
 
-
-def main() -> None:
+def main():
     data = json.loads(JSON_PATH.read_text(encoding="utf-8"))
-    items = data.get("tournaments", []) if isinstance(data, dict) else []
-    inserted = import_items(items)
-    print(f"✅ Importé: {inserted} lignes depuis {JSON_PATH} → {DB_PATH}")
-
+    items = data.get("tournaments", [])
+    print(f"📄 Lecture JSON: {JSON_PATH}  items={len(items)}")
+    rows_after = import_items(items)
+    print(f"🗃  DB rows now: {rows_after}  (→ {DB_PATH})")
 
 if __name__ == "__main__":
     main()

--- a/services/manual_scrape.py
+++ b/services/manual_scrape.py
@@ -111,8 +111,9 @@ def main() -> None:
         OUT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         SNAPSHOT.write_text(page.content(), encoding="utf-8")
 
-        inserted = import_items(all_items)
-        print(f"🗃  Import DB: +{inserted} nouvelles lignes → {DB_PATH}")
+        print(f"🧮 Import: {len(all_items)} items -> {DB_PATH}")
+        rows_after = import_items(all_items)
+        print(f"🗃  DB rows now: {rows_after}  (fichier: {DB_PATH})")
         print("✅ Fin du workflow: scrape → JSON/snapshot → DB (auto)")
 
         context.close()


### PR DESCRIPTION
## Summary
- replace the tournament importer with an UPSERT-based workflow that logs validation results and table counts
- show explicit import feedback in the manual scraper output
- refresh the JSON import helper to surface item counts and resulting database rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4470456d08321bae3aa5d29ee0339