### PR TITLE
Refactor tournament storage and maintenance workflows

### DIFF
--- a/Import-From-JSON.command
+++ b/Import-From-JSON.command
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")"
-[ -d ".venv" ] && source .venv/bin/activate
-python -m services.import_from_json

--- a/Repair-DB.command
+++ b/Repair-DB.command
@@ -4,7 +4,8 @@ cd "$(dirname "$0")"
 
 LOG_DIR="data/logs"
 mkdir -p "$LOG_DIR"
-exec > >(tee -a "$LOG_DIR/healthcheck.log") 2>&1
+exec > >(tee -a "$LOG_DIR/repair.log") 2>&1
 
 [ -d ".venv" ] && source .venv/bin/activate
-python -m tools.healthcheck
+
+python -m tools.repair_db

--- a/Reset-DB.command
+++ b/Reset-DB.command
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")"
-rm -f data/app.db
-echo "🧹 Base supprimée (data/app.db). Elle sera recréée au prochain import."

--- a/Scrape-Manual-Full.command
+++ b/Scrape-Manual-Full.command
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")"
+
+LOG_DIR="data/logs"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_DIR/scrape.log") 2>&1
+
 [ -d ".venv" ] && source .venv/bin/activate
+
 echo "🟢 Scraping semi-auto + import DB"
 python -m services.manual_scrape
+
 echo "✅ Terminé — les tournois sont à jour dans l’app"

--- a/Scrape-Then-Healthcheck.command
+++ b/Scrape-Then-Healthcheck.command
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")"
-[ -d ".venv" ] && source .venv/bin/activate
-echo "🟢 Scrape manuel puis healthcheck"
-python -m services.manual_scrape
-python -m tools.healthcheck

--- a/Start-TenPadel.command
+++ b/Start-TenPadel.command
@@ -2,6 +2,10 @@
 set -euo pipefail
 cd "$(dirname "$0")" || exit 1
 
+LOG_DIR="data/logs"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_DIR/server.log") 2>&1
+
 echo "🚀 Starting TenPadel…"
 
 PY="/usr/local/bin/python3"
@@ -16,8 +20,13 @@ pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt
 python -m playwright install chromium
 
-mkdir -p data data/logs
+mkdir -p data "$LOG_DIR"
 touch data/app.db
+ensure_schema_py='from services.db_import import ensure_schema; ensure_schema()'
+python - <<PY
+$ensure_schema_py
+PY
+
 touch data/tournaments.json
 chmod -R u+rwX,go+rwX data
 

--- a/Stop-TenPadel.command
+++ b/Stop-TenPadel.command
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+LOG_DIR="data/logs"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_DIR/server.log") 2>&1
+
+echo "🛑 Stopping TenPadel…"
+PIDS=$(pgrep -f "[p]ython.*app.py" || true)
+if [ -z "$PIDS" ]; then
+  echo "Aucun serveur TenPadel actif."
+  exit 0
+fi
+
+for pid in $PIDS; do
+  echo "→ kill $pid"
+  kill "$pid" || true
+done
+
+echo "✅ Stop demandé."

--- a/api/tournaments.py
+++ b/api/tournaments.py
@@ -1,43 +1,37 @@
 """REST API endpoints exposing TenUp tournaments."""
 from __future__ import annotations
 
-from flask import Blueprint, jsonify, request
 import sqlite3
+from typing import Optional
 
+from flask import Blueprint, jsonify, request
+
+from services.db_import import ensure_schema, fetch_all_tournaments
 from tenpadel.config_paths import DB_PATH
 
 bp = Blueprint("tournaments", __name__)
 
 
-def _fetch_all(limit: int = 1000):
-    con = sqlite3.connect(str(DB_PATH))
-    con.row_factory = sqlite3.Row
-    cur = con.cursor()
-    cur.execute(
-        """
-        SELECT id, name, category, level, club_name, city,
-               start_date, end_date, detail_url, registration_url
-        FROM tournaments
-        ORDER BY (start_date IS NULL), start_date ASC, id DESC
-        LIMIT ?
-    """,
-        (limit,),
-    )
-    rows = [dict(r) for r in cur.fetchall()]
-    con.close()
-    for r in rows:
-        r["date"] = r.get("start_date")
-    return rows
+def _parse_limit(value: Optional[str]) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(1, limit)
 
 
 @bp.route("/api/tournaments")
 def list_tournaments():
-    limit = int(request.args.get("limit", 1000))
-    return jsonify(_fetch_all(limit))
+    limit = _parse_limit(request.args.get("limit"))
+    items = fetch_all_tournaments(limit=limit)
+    return jsonify(items)
 
 
 @bp.route("/api/_count")
 def count():
+    ensure_schema()
     con = sqlite3.connect(str(DB_PATH))
     cur = con.cursor()
     cur.execute("SELECT COUNT(*) FROM tournaments")

--- a/services/import_from_json.py
+++ b/services/import_from_json.py
@@ -6,8 +6,13 @@ def main():
     data = json.loads(JSON_PATH.read_text(encoding="utf-8"))
     items = data.get("tournaments", [])
     print(f"📄 Lecture JSON: {JSON_PATH}  items={len(items)}")
-    rows_after = import_items(items)
-    print(f"🗃  DB rows now: {rows_after}  (→ {DB_PATH})")
+    stats = import_items(items)
+    print(
+        f"   ↳ Inserted: {stats.inserted}  Updated: {stats.updated}  Unchanged: {stats.skipped}"
+    )
+    if stats.reasons:
+        print(f"   ↳ Ignored: {stats.total - stats.valid} {stats.reasons}")
+    print(f"🗃  DB rows now: {stats.rows_after}  (→ {DB_PATH})")
 
 if __name__ == "__main__":
     main()

--- a/services/manual_scrape.py
+++ b/services/manual_scrape.py
@@ -112,8 +112,14 @@ def main() -> None:
         SNAPSHOT.write_text(page.content(), encoding="utf-8")
 
         print(f"🧮 Import: {len(all_items)} items -> {DB_PATH}")
-        rows_after = import_items(all_items)
-        print(f"🗃  DB rows now: {rows_after}  (fichier: {DB_PATH})")
+        stats = import_items(all_items)
+        print(
+            f"   ↳ Inserted: {stats.inserted}  Updated: {stats.updated}  Unchanged: {stats.skipped}"
+        )
+        if stats.reasons:
+            skipped_details = ", ".join(f"{k}={v}" for k, v in sorted(stats.reasons.items()))
+            print(f"   ↳ Ignored: {stats.total - stats.valid} ({skipped_details})")
+        print(f"🗃  DB rows now: {stats.rows_after}  (fichier: {DB_PATH})")
         print("✅ Fin du workflow: scrape → JSON/snapshot → DB (auto)")
 
         context.close()

--- a/services/tournament_store.py
+++ b/services/tournament_store.py
@@ -1,22 +1,14 @@
-"""Helpers to persist scraped tournaments to JSON and SQLite."""
+"""Compatibility wrapper for legacy TournamentStore usage."""
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Mapping
 
-from flask_sqlalchemy import SQLAlchemy
-
-from services.tournament_store_models import TournamentRecord
+from services.db_import import export_db_to_json, import_items
 
 
-def _ensure_directory(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
-@dataclass
+@dataclass(slots=True)
 class UpsertResult:
     inserted: int = 0
     updated: int = 0
@@ -33,52 +25,21 @@ class UpsertResult:
 class TournamentStore:
     """Persist tournaments to SQLite and JSON outputs."""
 
-    def __init__(self, db: SQLAlchemy, json_path: Path) -> None:
-        self._db = db
+    def __init__(self, _db, json_path: Path) -> None:  # pragma: no cover - compatibility signature
         self._json_path = json_path
-        _ensure_directory(self._json_path)
+        self._json_path.parent.mkdir(parents=True, exist_ok=True)
 
     def upsert_many(self, records: Iterable[Mapping[str, object]]) -> UpsertResult:
-        session = self._db.session
-        stats = UpsertResult()
-        now = datetime.utcnow()
-
-        for payload in records:
-            data = dict(payload)
-            tournament_id = str(data["tournament_id"])
-            existing = (
-                session.query(TournamentRecord)
-                .filter(TournamentRecord.tournament_id == tournament_id)
-                .one_or_none()
-            )
-            if existing is None:
-                instance = TournamentRecord(**data)
-                instance.created_at = now
-                instance.updated_at = now
-                session.add(instance)
-                stats.inserted += 1
-                continue
-
-            changed = existing.update_from_payload(data)
-            if changed:
-                existing.updated_at = now
-                stats.updated += 1
-            else:
-                stats.skipped += 1
-
-        session.commit()
+        stats = import_items(records)
         self._export_json()
-        return stats
+        return UpsertResult(
+            inserted=stats.inserted,
+            updated=stats.updated,
+            skipped=stats.skipped,
+        )
 
     def _export_json(self) -> None:
-        session = self._db.session
-        rows = session.query(TournamentRecord).order_by(TournamentRecord.start_date.asc()).all()
-        payload = [row.to_dict() for row in rows]
-        _ensure_directory(self._json_path)
-        self._json_path.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        export_db_to_json(self._json_path)
 
 
 __all__ = ["TournamentStore", "UpsertResult"]

--- a/tools/healthcheck.py
+++ b/tools/healthcheck.py
@@ -1,13 +1,9 @@
 # tools/healthcheck.py
 import json, sqlite3, time, re, urllib.request, sys
-from pathlib import Path
 from datetime import datetime
 
-BASE = Path(__file__).resolve().parent.parent
-DATA = BASE / "data"
-DB   = DATA / "app.db"
-JSONF= DATA / "tournaments.json"
-LOGD = DATA / "logs"
+from tenpadel.config_paths import DB_PATH as DB, JSON_PATH as JSONF, LOG_DIR as LOGD
+
 API  = "http://127.0.0.1:5000/api/tournaments"
 
 def stamp(p: Path):

--- a/tools/repair_db.py
+++ b/tools/repair_db.py
@@ -1,0 +1,79 @@
+"""Repair the SQLite database schema and reload tournaments from JSON."""
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from services.db_import import ImportStats, ensure_schema, import_items
+from tenpadel.config_paths import DB_PATH, JSON_PATH, LOG_DIR
+
+
+def backup_database() -> Path | None:
+    if not DB_PATH.exists():
+        return None
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_path = DB_PATH.with_name(f"{DB_PATH.name}.bak-{timestamp}")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(DB_PATH, backup_path)
+    return backup_path
+
+
+def recreate_schema() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(DB_PATH))
+    cur = con.cursor()
+    cur.execute("DROP TABLE IF EXISTS tournaments")
+    cur.execute("DROP INDEX IF EXISTS idx_unique_detail_url")
+    cur.execute("DROP INDEX IF EXISTS idx_start_date")
+    con.commit()
+    con.close()
+    ensure_schema()
+
+
+def read_json_payload() -> list[dict]:
+    if not JSON_PATH.exists():
+        print(f"⚠️  JSON file missing: {JSON_PATH}")
+        return []
+    raw = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        return [dict(item) for item in raw]
+    if isinstance(raw, dict):
+        candidates = raw.get("tournaments") or raw.get("items") or []
+        if isinstance(candidates, list):
+            return [dict(item) for item in candidates]
+    print(f"⚠️  Unsupported JSON structure in {JSON_PATH}")
+    return []
+
+
+def import_current_json() -> ImportStats:
+    items = read_json_payload()
+    print(f"📥 Importing {len(items)} tournaments from {JSON_PATH}")
+    return import_items(items)
+
+
+def main() -> int:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    backup = backup_database()
+    if backup:
+        print(f"🗃️  Backup created: {backup}")
+
+    recreate_schema()
+    print("✅ Schema recreated")
+
+    stats = import_current_json()
+    print(
+        "   ↳ Inserted: {0.inserted}  Updated: {0.updated}  Unchanged: {0.skipped}".format(stats)
+    )
+    if stats.reasons:
+        print(f"   ↳ Ignored: {stats.total - stats.valid} {stats.reasons}")
+    print(f"📊 Database rows: {stats.rows_after} (file: {DB_PATH})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- overhaul the SQLite import pipeline to guarantee the expected schema, compute fallback tournament identifiers, and provide detailed import statistics and exports
- expose tournament data via the unified helpers, ensure the app bootstraps the schema, and streamline the scrape utilities to rely on the shared importer
- add a repair utility and refresh the .command scripts so maintenance actions log to data/logs and remove the deprecated entry points

## Testing
- python -m compileall services app.py api tools tenpadel
- python -m tools.repair_db


------
https://chatgpt.com/codex/tasks/task_e_68e44d84d98c8321aaeffae1088cca8d